### PR TITLE
Add sanity checks and improve getEntity function

### DIFF
--- a/src/actions/public/getEntity.ts
+++ b/src/actions/public/getEntity.ts
@@ -1,14 +1,29 @@
-import type { Hex } from "viem"
+import { bytesToHex, type Hex, hexToBytes } from "viem"
 import type { ArkivClient } from "../../clients/baseClient"
 import { NoEntityFoundError } from "../../query/errors"
 import { entityFromRpcResult } from "../../utils/entities"
 
 export async function getEntity(client: ArkivClient, key: Hex) {
+  // Normalize the key into bytes
+  let bytes: Uint8Array
+  try {
+    bytes = hexToBytes(key)
+  } catch {
+    throw new Error(`Invalid key format: ${key}. Key must be a valid hex string.`)
+  }
+
+  if (bytes.length !== 32) {
+    throw new Error(
+      `Invalid key length: ${bytes.length} bytes. Key must be 32 bytes (64 hex characters) long.`,
+    )
+  }
+
+  const hexKey = bytesToHex(bytes)
+
   const result = await client.request({
     method: "arkiv_query",
-    params: [`$key = ${key}`],
+    params: [`$key = ${hexKey}`],
   })
-  console.debug("GetEntity result", result)
 
   if (!result.data) {
     throw new NoEntityFoundError()


### PR DESCRIPTION
Sanitizing input prevents misleading errors when provided with wrongly formatted key.  