### PR TITLE
`select` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,11 @@ console.log('Chain ID:', chainId);
 const entity = await publicClient.getEntity('0xcadb830a3414251d65e5c92cd28ecb648d9e73d85f2203eff631839d5421f9d7');
 console.log('Entity:', entity);
 
-// Build and execute a query using QueryBuilder
-const query = publicClient.buildQuery();
-const result = await query
+// Build and execute a query using select()
+const result = await publicClient
+  .select({ owner: true, attributes: true, payload: true })
   .where(eq('category', 'documentation'))
   .ownedBy('0x6186B0DbA9652262942d5A465d49686eb560834C')
-  .withAttributes(true)
-  .withPayload(true)
   .limit(10)
   .fetch();
 
@@ -132,6 +130,39 @@ if (result.hasNextPage()) {
   console.log('Next page:', result.entities);
 }
 ```
+
+#### Selecting fields with `select()`
+
+Pass nothing (or `"*"`) to fetch everything, or pass an object to fetch only specific fields:
+
+```typescript
+// All fields
+await publicClient.select().where(eq("category", "docs")).fetch();
+
+// Only the fields you need
+await publicClient.select({ key: true, owner: true, payload: true }).where(eq("category", "docs")).fetch();
+```
+
+**Select only what you need.** Every selected field is fetched over the network, so requesting
+data you won't use makes queries slower. Narrowing the selection keeps responses small and fast.
+
+The result type is inferred from your selection: reading a field you didn't select is a compile error. The `toText()` / `toJson()` payload
+helpers are available only when you select `payload`.
+
+```typescript
+const [entity] = (await publicClient.select({ owner: true, payload: true }).fetch()).entities;
+entity.owner;     // ✅ Hex
+entity.toJson();  // ✅ payload was selected
+entity.creator;   // ❌ compile error — not selected
+```
+
+> **Footgun:** pass the selection inline. A selection stored in a variable widens its `true` values
+> to `boolean`, so the result type can't be narrowed (you get `{}` and a compile error on every
+> field). If you need to reuse one, annotate it `as const`:
+> ```typescript
+> const fields = { owner: true, payload: true } as const;
+> await publicClient.select(fields).where(eq("category", "docs")).fetch();
+> ```
 
 ### Running the Example
 

--- a/sample/read_example.ts
+++ b/sample/read_example.ts
@@ -19,13 +19,14 @@ const entity = await publicClient.getEntity(
 )
 console.log("Entity:", entity)
 
-// Build and execute a query using QueryBuilder
-const query = publicClient.buildQuery()
-const result = await query
+// Build and execute a query using select().
+// select() declares up front what to return: select() / select("*") returns everything,
+// or pass an object to pick specific fields. The selection is flat and the result type is
+// narrowed to exactly the selected fields.
+const result = await publicClient
+  .select({ key: true, owner: true, attributes: true, payload: true })
   .where(eq("category", "documentation"))
   .ownedBy("0xF46E23f6a6F6336D4C64D5D1c95599bF77a536f0")
-  .withAttributes(true)
-  .withPayload(true)
   .limit(10)
   .fetch()
 

--- a/src/actions/public/buildQuery.ts
+++ b/src/actions/public/buildQuery.ts
@@ -1,6 +1,10 @@
 import type { ArkivClient } from "../../clients/baseClient"
 import { QueryBuilder } from "../../query/queryBuilder"
 
+/**
+ * @deprecated Use `client.select()` (see SelectQueryBuilder) instead. `buildQuery()` returns
+ * only the entity `key` unless data is explicitly opted in to, which is an easy mistake.
+ */
 export async function buildQuery(client: ArkivClient) {
   return new QueryBuilder(client)
 }

--- a/src/clients/createPublicClient.test.ts
+++ b/src/clients/createPublicClient.test.ts
@@ -20,6 +20,8 @@ test("creates", () => {
   expect(typeof client.getEntity).toBe("function")
   expect(client.buildQuery).toBeDefined()
   expect(typeof client.buildQuery).toBe("function")
+  expect(client.select).toBeDefined()
+  expect(typeof client.select).toBe("function")
   expect(client.query).toBeDefined()
   expect(typeof client.query).toBe("function")
   expect(client.getEntityCount).toBeDefined()

--- a/src/clients/decorators/arkivPublic.ts
+++ b/src/clients/decorators/arkivPublic.ts
@@ -4,7 +4,8 @@ import { getEntity } from "../../actions/public/getEntity"
 import { getEntityCount } from "../../actions/public/getEntityCount"
 import { type QueryOptions, type QueryReturnType, query } from "../../actions/public/query"
 import { subscribeEntityEvents } from "../../actions/public/subscribeEntityEvents"
-import { QueryBuilder } from "../../query/queryBuilder"
+import { QueryBuilder, SelectQueryBuilder } from "../../query/queryBuilder"
+import type { EntitySelection, FullEntity, ProjectedEntity, SelectArg } from "../../query/selection"
 import type { Entity } from "../../types/entity"
 import type {
   OnEntityCreatedEvent,
@@ -56,10 +57,74 @@ export type PublicArkivActions<
   getEntity: (key: Hex) => Promise<Entity>
 
   /**
+   * Returns a SelectQueryBuilder for building and executing queries — the recommended way to
+   * read entities. You declare up front which parts of an entity you want returned, so results
+   * always contain exactly the data you asked for.
+   *
+   * - Docs: https://docs.arkiv.network/ts-sdk/actions/public/query
+   *
+   * @param selection - What to include in the results. Omit it (or pass `"*"`) to select everything,
+   *   or pass an object to select specific parts (at least one field is required). Every part is
+   *   opt-in, including the `key`. The selection is flat — each field maps to an entity field.
+   *   {@link SelectArg}
+   * @returns A SelectQueryBuilder instance for building and executing queries. {@link SelectQueryBuilder}
+   *
+   * @example
+   * import { createPublicClient, http } from 'arkiv'
+   * import { braga } from 'arkiv/chains'
+   * import { eq } from 'arkiv/query'
+   *
+   * const client = createPublicClient({
+   *   chain: braga,
+   *   transport: http(),
+   * })
+   * // select everything
+   * await client.select().where(eq("category", "docs")).fetch()
+   * await client.select("*").where(eq("category", "docs")).fetch()
+   * // only the key
+   * await client.select({ key: true }).where(eq("category", "docs")).fetch()
+   * // select specific fields — result typed { owner: Hex; attributes: Attribute[] }
+   * await client.select({ owner: true, attributes: true }).fetch()
+   * // a single field — result typed { owner: Hex }
+   * await client.select({ owner: true }).fetch()
+   */
+  select: {
+    /** Select every field. Pass nothing or `"*"`; the returned entities contain all fields. */
+    (selection?: "*"): SelectQueryBuilder<FullEntity>
+    /**
+     * Pick the entity fields to return. Set the ones you want to `true` (at least one is required);
+     * the result is typed to exactly those fields, so reading anything else is a compile error.
+     *
+     * Available fields: `key`, `owner`, `creator`, `contentType`, `payload`, `attributes`,
+     * `expiresAtBlock`, `createdAtBlock`, `lastModifiedAtBlock`, `transactionIndexInBlock`,
+     * `operationIndexInTransaction`.
+     *
+     * Pass the selection inline so its fields stay literal `true`. A selection stored in a `let`/
+     * `const` variable widens to `boolean` and the result type can no longer be narrowed — annotate
+     * it `as const` (e.g. `const sel = { owner: true } as const`) in that case.
+     *
+     * @example
+     * client.select({ owner: true, attributes: true }) // entities typed { owner, attributes }
+     * client.select({ key: true, payload: true })       // includes payload → toText()/toJson() too
+     */
+    <const S extends EntitySelection>(selection: S): SelectQueryBuilder<ProjectedEntity<S>>
+    /**
+     * Dynamic selection: accepts a value typed {@link SelectArg} (e.g. built at runtime). The
+     * result cannot be narrowed in this case, so the entities are typed as the full entity.
+     */
+    (selection: SelectArg): SelectQueryBuilder<FullEntity>
+  }
+
+  /**
    * Returns a QueryBuilder instance for building and executing queries.
    * The QueryBuilder object follows the Builder pattern, allowing you to chain methods to build a query and then execute it.
    *
    * - Docs: https://docs.arkiv.network/ts-sdk/actions/public/query
+   *
+   * @deprecated Use {@link select} instead. `buildQuery()` returns only the entity `key` unless
+   * you remember to opt in to data with `withAttributes()`/`withMetadata()`/`withPayload()`, which
+   * is an easy mistake. `select()` makes the selection explicit. This method remains for backwards
+   * compatibility and will be removed in a future release.
    *
    * @returns A QueryBuilder instance for building and executing queries. {@link QueryBuilder}
    *
@@ -200,6 +265,7 @@ export function publicArkivActions<
     getEntity: (key: Hex) => getEntity(client, key),
     query: (rawQuery: string, queryOptions?: QueryOptions) => query(client, rawQuery, queryOptions),
     buildQuery: () => new QueryBuilder(client),
+    select: (selection?: SelectArg) => new SelectQueryBuilder(client, selection),
     getBlockTiming: () => getBlockTiming(client),
     getEntityCount: () => getEntityCount(client),
     subscribeEntityEvents: (

--- a/src/query/engine.ts
+++ b/src/query/engine.ts
@@ -55,6 +55,11 @@ export async function processQuery(
     withAttributes?: boolean | undefined
     withMetadata?: boolean | undefined
     withPayload?: boolean | undefined
+    /**
+     * Fully-resolved include-data for fine-grained selection. When provided it takes
+     * precedence over the `withAttributes`/`withMetadata`/`withPayload` booleans.
+     */
+    includeData?: RpcIncludeData | undefined
   },
 ) {
   const {
@@ -68,6 +73,7 @@ export async function processQuery(
     withAttributes,
     withMetadata,
     withPayload,
+    includeData,
   } = queryParams
 
   logger("Processing query with params %o", {
@@ -81,6 +87,7 @@ export async function processQuery(
     withAttributes,
     withMetadata,
     withPayload,
+    includeData,
   })
 
   let query = processPredicates(predicates)
@@ -98,19 +105,21 @@ export async function processQuery(
   }
 
   const queryOptions: RpcQueryOptions = {
-    includeData: {
-      key: true,
-      attributes: withAttributes ?? false,
-      payload: withPayload ?? false,
-      contentType: withMetadata ?? false,
-      expiration: withMetadata ?? false,
-      owner: withMetadata ?? false,
-      creator: withMetadata ?? false,
-      createdAtBlock: withMetadata ?? false,
-      lastModifiedAtBlock: withMetadata ?? false,
-      transactionIndexInBlock: withMetadata ?? false,
-      operationIndexInTransaction: withMetadata ?? false,
-    } as RpcIncludeData,
+    includeData:
+      includeData ??
+      ({
+        key: true,
+        attributes: withAttributes ?? false,
+        payload: withPayload ?? false,
+        contentType: withMetadata ?? false,
+        expiration: withMetadata ?? false,
+        owner: withMetadata ?? false,
+        creator: withMetadata ?? false,
+        createdAtBlock: withMetadata ?? false,
+        lastModifiedAtBlock: withMetadata ?? false,
+        transactionIndexInBlock: withMetadata ?? false,
+        operationIndexInTransaction: withMetadata ?? false,
+      } as RpcIncludeData),
   }
 
   if (validAtBlock !== undefined) {

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,3 +1,4 @@
 export * from "./predicate"
 export * from "./queryBuilder"
 export * from "./queryResult"
+export * from "./selection"

--- a/src/query/queryBuilder.ts
+++ b/src/query/queryBuilder.ts
@@ -1,10 +1,12 @@
 import type { Hex } from "viem"
 import type { ArkivClient } from "../clients/baseClient"
-import type { RpcOrderByAttribute } from "../types/rpcSchema"
+import type { Entity } from "../types/entity"
+import type { RpcEntity, RpcIncludeData, RpcOrderByAttribute } from "../types/rpcSchema"
 import { entityFromRpcResult } from "../utils/entities"
 import { processQuery } from "./engine"
 import type { Predicate } from "./predicate"
 import { QueryResult } from "./queryResult"
+import { type SelectArg, selectionToIncludeData } from "./selection"
 
 export type OrderByAttribute = {
   name: string
@@ -45,24 +47,37 @@ export function desc(attributeName: string, attributeType: "string" | "number"):
     order: "desc",
   }
 }
+
 /**
- * QueryBuilder is a helper class to build queries to the Arkiv DBChains.
- * It can be used to fetch entities from the Arkiv DBChains. It follows the Builder pattern allowing chaining of methods.
- * @param client - The Arkiv client
- * @returns The QueryBuilder instance {@link QueryBuilder}
+ * Data-selection parameters forwarded to the query engine on each fetch.
+ * Subclasses of {@link BaseQueryBuilder} decide which parts of an entity are fetched.
  */
-export class QueryBuilder {
-  private _client: ArkivClient
-  private _ownedBy: Hex | undefined
-  private _createdBy: Hex | undefined
-  private _orderBy: RpcOrderByAttribute[] | undefined
-  private _validAtBlock: bigint | undefined
-  private _withAttributes: boolean | undefined
-  private _withMetadata: boolean | undefined
-  private _withPayload: boolean | undefined
-  private _limit: number | undefined
-  private _cursor: string | undefined
-  private _predicates: Predicate[]
+type SelectionParams = {
+  withAttributes?: boolean | undefined
+  withMetadata?: boolean | undefined
+  withPayload?: boolean | undefined
+  includeData?: RpcIncludeData | undefined
+}
+
+/**
+ * BaseQueryBuilder holds the query-building logic shared by every query builder
+ * (filtering, ordering, pagination, execution). It follows the Builder pattern,
+ * allowing methods to be chained. Subclasses decide how data selection is expressed
+ * by implementing the protected `selectionParams` method.
+ *
+ * Use {@link SelectQueryBuilder} via `client.select()` to build and execute queries.
+ *
+ * @typeParam TEntity - The shape of each entity produced by {@link BaseQueryBuilder.fetch}.
+ */
+export abstract class BaseQueryBuilder<TEntity> {
+  protected _client: ArkivClient
+  protected _ownedBy: Hex | undefined
+  protected _createdBy: Hex | undefined
+  protected _orderBy: RpcOrderByAttribute[] | undefined
+  protected _validAtBlock: bigint | undefined
+  protected _limit: number | undefined
+  protected _cursor: string | undefined
+  protected _predicates: Predicate[]
 
   constructor(client: ArkivClient) {
     this._client = client
@@ -72,13 +87,13 @@ export class QueryBuilder {
   /**
    * Sets the ownedBy filter
    * @param ownedBy - The address of the owner
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * builder.ownedBy("0x1234567890123456789012345678901234567890")
    */
-  ownedBy(ownedBy: Hex) {
+  ownedBy(ownedBy: Hex): this {
     this._ownedBy = ownedBy
     return this
   }
@@ -86,13 +101,13 @@ export class QueryBuilder {
   /**
    * Sets the createdBy filter
    * @param createdBy - The address of the creator
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * builder.createdBy("0x1234567890123456789012345678901234567890")
    */
-  createdBy(createdBy: Hex) {
+  createdBy(createdBy: Hex): this {
     this._createdBy = createdBy
     return this
   }
@@ -105,10 +120,10 @@ export class QueryBuilder {
    * @param attributeName - The name of the attribute to order by
    * @param attributeType - The type of the attribute to order by (string or number)
    * @param order - The order to set the order by (asc or desc)
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = client.buildQuery()
+   * const builder = client.select()
    * builder.orderBy("name", "string", "desc")
    * builder.orderBy(asc("name", "string"))
    * builder.orderBy(desc("name", "string"))
@@ -119,10 +134,10 @@ export class QueryBuilder {
    * This method takes the OrderByAttribute object as an argument and is mainly
    * used to use the helper functions asc() and desc() to create the OrderByAttribute instances.
    * @param orderByAttribute - The OrderByAttribute instance to set
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * builder.orderBy(asc("name", "string"))
    * builder.orderBy(desc("name", "string"))
    */
@@ -131,7 +146,7 @@ export class QueryBuilder {
     attributeNameOrOrderByAttribute: string | OrderByAttribute,
     attributeType?: "string" | "number",
     order: "asc" | "desc" = "asc",
-  ) {
+  ): this {
     if (!this._orderBy) {
       this._orderBy = []
     }
@@ -161,57 +176,15 @@ export class QueryBuilder {
   }
 
   /**
-   * Sets the withAttributes flag which will return the attributes for the entities if true
-   * @param withAttributes - The boolean value to set
-   * @returns The QueryBuilder instance
-   *
-   * @example
-   * const builder = new QueryBuilder(client)
-   * builder.withAttributes(true)
-   */
-  withAttributes(withAttributes: boolean = true) {
-    this._withAttributes = withAttributes
-    return this
-  }
-
-  /**
-   * Sets the withMetadata flag which will return the metadata (like owner, expiredAt, etc.) for the entities if true
-   * @param withMetadata - The boolean value to set
-   * @returns The QueryBuilder instance
-   *
-   * @example
-   * const builder = new QueryBuilder(client)
-   * builder.withMetadata(true)
-   */
-  withMetadata(withMetadata: boolean = true) {
-    this._withMetadata = withMetadata
-    return this
-  }
-
-  /**
-   * Sets the withPayload flag which will return the payload for the entities if true
-   * @param withPayload - The boolean value to set
-   * @returns The QueryBuilder instance
-   *
-   * @example
-   * const builder = new QueryBuilder(client)
-   * builder.withPayload(true)
-   */
-  withPayload(withPayload: boolean = true) {
-    this._withPayload = withPayload
-    return this
-  }
-
-  /**
    * Sets the limit for the query
    * @param limit - The number of entities to return
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * builder.limit(10)
    */
-  limit(limit: number) {
+  limit(limit: number): this {
     this._limit = limit
     return this
   }
@@ -219,13 +192,13 @@ export class QueryBuilder {
   /**
    * Sets the cursor for the query - it is advances setting which rather shouldn't be used manually but it is provided from query result if limit is used (pagination).
    * @param cursor - The cursor to set which tells to RPC Query server where to start or continue the query.
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
-   * builder.offset(10)
+   * const builder = client.select()
+   * builder.cursor("0xABC123")
    */
-  cursor(cursor: string) {
+  cursor(cursor: string): this {
     this._cursor = cursor
     return this
   }
@@ -234,13 +207,13 @@ export class QueryBuilder {
    * Sets the validAtBlock for the query which tells at which block height the state we are intested.
    * If not set, the latest block is  used.
    * @param validAtBlock - The block number to set
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * builder.validAtBlock(10000)
    */
-  validAtBlock(validAtBlock: bigint) {
+  validAtBlock(validAtBlock: bigint): this {
     this._validAtBlock = validAtBlock
     return this
   }
@@ -249,10 +222,10 @@ export class QueryBuilder {
    * Sets the predicates for the query limiting the results. It can be a single predicate or an array of predicates combined with 'and'.
    * Predicates can be nested using 'or' and 'and' predicates.
    * @param predicates - The predicates to set
-   * @returns The QueryBuilder instance
+   * @returns The query builder instance
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * builder.where(eq("name", "John"))
    * builder.where([eq("name", "John"), eq("age", 30)])
    * builder.where([eq("name", "John"), or([eq("age", 30), eq("age", 31)])])
@@ -261,7 +234,7 @@ export class QueryBuilder {
    * builder.where([eq("name", "John"), and([eq("age", 30), or([eq("age", 31), eq("age", 32)])])])
    * builder.where([eq("name", "John"), and([eq("age", 30), or([eq("age", 31), and([eq("age", 32), eq("age", 33)])])])])
    */
-  where(predicates: Predicate[] | Predicate) {
+  where(predicates: Predicate[] | Predicate): this {
     if (Array.isArray(predicates)) {
       this._predicates.push(...predicates)
     } else {
@@ -271,16 +244,28 @@ export class QueryBuilder {
   }
 
   /**
-   * Fetches the entities from the query. Re
+   * Returns the data-selection parameters forwarded to the query engine.
+   * Subclasses decide which parts of an entity are fetched.
+   */
+  protected abstract selectionParams(): SelectionParams
+
+  /**
+   * Builds a single result entity from a raw RPC entity. Subclasses decide the produced shape
+   * (a full {@link Entity}, or a projected object inferred from the selection).
+   */
+  protected abstract projectEntity(rpcEntity: RpcEntity): TEntity | Promise<TEntity>
+
+  /**
+   * Fetches the entities from the query.
    * It will return a QueryResult instance which can be used to fetch the next and previous pages.
    * @returns The QueryResult instance {@link QueryResult}
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * const result = await builder.where(eq("name", "John")).fetch()
    * // result = { entities: [Entity, Entity, Entity], next: async () => QueryResult, previous: async () => QueryResult }
    */
-  async fetch() {
+  async fetch(): Promise<QueryResult<TEntity>> {
     const queryResult = await processQuery(this._client, {
       predicates: this._predicates,
       limit: this._limit,
@@ -289,19 +274,15 @@ export class QueryBuilder {
       createdBy: this._createdBy,
       orderBy: this._orderBy,
       validAtBlock: this._validAtBlock,
-      withAttributes: this._withAttributes,
-      withMetadata: this._withMetadata,
-      withPayload: this._withPayload,
+      ...this.selectionParams(),
     })
 
-    const entities = await Promise.all(
-      queryResult.data.map((entity) => entityFromRpcResult(entity)),
-    )
+    const entities = await Promise.all(queryResult.data.map((entity) => this.projectEntity(entity)))
 
     this.cursor(queryResult.cursor)
     this.validAtBlock(BigInt(queryResult.blockNumber ?? 0))
 
-    return new QueryResult(entities, this, this._cursor, this._limit, this._validAtBlock)
+    return new QueryResult<TEntity>(entities, this, this._cursor, this._limit, this._validAtBlock)
   }
 
   /**
@@ -309,7 +290,7 @@ export class QueryBuilder {
    * @returns The number of entities
    *
    * @example
-   * const builder = new QueryBuilder(client)
+   * const builder = client.select()
    * const result = await builder.where(eq("name", "John")).count()
    * // result = 10
    */
@@ -328,5 +309,119 @@ export class QueryBuilder {
     })
 
     return queryResult.data.length ?? 0
+  }
+}
+
+/**
+ * QueryBuilder is a helper class to build queries to the Arkiv DBChains.
+ * It can be used to fetch entities from the Arkiv DBChains. It follows the Builder pattern allowing chaining of methods.
+ *
+ * By default the result includes only the entity `key`. Additional data is opt-in through
+ * `withAttributes()`, `withMetadata()` and `withPayload()`.
+ *
+ * @deprecated Use {@link SelectQueryBuilder} via `client.select()` instead. Declaring the
+ * selection up front avoids the common mistake of forgetting to opt in to data and getting back
+ * entities with only their `key` populated. This class remains for backwards compatibility and
+ * will be removed in a future release.
+ *
+ * @param client - The Arkiv client
+ * @returns The QueryBuilder instance {@link QueryBuilder}
+ */
+export class QueryBuilder extends BaseQueryBuilder<Entity> {
+  private _withAttributes: boolean | undefined
+  private _withMetadata: boolean | undefined
+  private _withPayload: boolean | undefined
+
+  /**
+   * Sets the withAttributes flag which will return the attributes for the entities if true
+   * @param withAttributes - The boolean value to set
+   * @returns The QueryBuilder instance
+   *
+   * @example
+   * const builder = client.buildQuery()
+   * builder.withAttributes(true)
+   */
+  withAttributes(withAttributes: boolean = true): this {
+    this._withAttributes = withAttributes
+    return this
+  }
+
+  /**
+   * Sets the withMetadata flag which will return the metadata (like owner, expiredAt, etc.) for the entities if true
+   * @param withMetadata - The boolean value to set
+   * @returns The QueryBuilder instance
+   *
+   * @example
+   * const builder = client.buildQuery()
+   * builder.withMetadata(true)
+   */
+  withMetadata(withMetadata: boolean = true): this {
+    this._withMetadata = withMetadata
+    return this
+  }
+
+  /**
+   * Sets the withPayload flag which will return the payload for the entities if true
+   * @param withPayload - The boolean value to set
+   * @returns The QueryBuilder instance
+   *
+   * @example
+   * const builder = client.buildQuery()
+   * builder.withPayload(true)
+   */
+  withPayload(withPayload: boolean = true): this {
+    this._withPayload = withPayload
+    return this
+  }
+
+  protected selectionParams(): SelectionParams {
+    return {
+      withAttributes: this._withAttributes,
+      withMetadata: this._withMetadata,
+      withPayload: this._withPayload,
+    }
+  }
+
+  protected projectEntity(rpcEntity: RpcEntity): Promise<Entity> {
+    return entityFromRpcResult(rpcEntity)
+  }
+}
+
+/**
+ * SelectQueryBuilder is the recommended query builder. It requires the selection to be declared
+ * up front, so results always contain exactly the data you asked for — and the type of each
+ * returned entity is narrowed to exactly the selected fields.
+ *
+ * The selection is fixed at construction time and is flat — each field maps to an entity field.
+ * Create one via `client.select(...)` rather than constructing it directly, so the result type is
+ * inferred from the selection.
+ *
+ * @typeParam TEntity - The projected entity shape, inferred from the selection by `client.select()`.
+ *
+ * @example
+ * // everything
+ * await client.select().where(eq("name", "John")).fetch()
+ * await client.select("*").where(eq("name", "John")).fetch()
+ * // specific fields
+ * await client.select({ owner: true, attributes: true }).fetch()
+ * // a single field — result is typed (flat) { owner: Hex }
+ * await client.select({ owner: true }).fetch()
+ */
+export class SelectQueryBuilder<TEntity> extends BaseQueryBuilder<TEntity> {
+  private _includeData: RpcIncludeData
+
+  constructor(client: ArkivClient, selection?: SelectArg) {
+    super(client)
+    this._includeData = selectionToIncludeData(selection)
+  }
+
+  protected selectionParams(): SelectionParams {
+    return { includeData: this._includeData }
+  }
+
+  protected async projectEntity(rpcEntity: RpcEntity): Promise<TEntity> {
+    // The runtime value is a full Entity (with methods); the static type is narrowed to the
+    // selected fields via `client.select()`'s inference.
+    return (await entityFromRpcResult(rpcEntity)) as unknown as TEntity
   }
 }

--- a/src/query/queryResult.ts
+++ b/src/query/queryResult.ts
@@ -1,20 +1,26 @@
 import { NoCursorOrLimitError, NoMoreResultsError } from "../errors"
 import type { Entity } from "../types/entity"
 import { getLogger } from "../utils/logger"
-import type { QueryBuilder } from "./queryBuilder"
+import type { BaseQueryBuilder } from "./queryBuilder"
 
 const logger = getLogger("query:result")
 
-export class QueryResult {
-  entities: Entity[]
+/**
+ * The result of a query. Holds the fetched entities and supports cursor-based pagination.
+ *
+ * @typeParam TEntity - The shape of each entity, inferred from the query builder
+ *   (a full {@link Entity}, or a projected object inferred from a `select()` selection).
+ */
+export class QueryResult<TEntity = Entity> {
+  entities: TEntity[]
   private _endOfIteration: boolean
   private _cursor: string | undefined
   private _limit: number | undefined
   private _validAtBlock: bigint | undefined
-  private _queryBuilder: QueryBuilder
+  private _queryBuilder: BaseQueryBuilder<TEntity>
 
   // Public getters for internal state
-  get queryBuilder(): QueryBuilder {
+  get queryBuilder(): BaseQueryBuilder<TEntity> {
     return this._queryBuilder
   }
 
@@ -23,8 +29,8 @@ export class QueryResult {
   }
 
   constructor(
-    entities: Entity[],
-    queryBuilder: QueryBuilder,
+    entities: TEntity[],
+    queryBuilder: BaseQueryBuilder<TEntity>,
     cursor: string | undefined,
     limit: number | undefined,
     validAtBlock: bigint | undefined,

--- a/src/query/selectQueryBuilder.test.ts
+++ b/src/query/selectQueryBuilder.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test"
+import type { ArkivClient } from "../clients/baseClient"
+import type { Entity } from "../types/entity"
+import * as entitiesUtils from "../utils/entities"
+import * as engine from "./engine"
+import { eq, gte } from "./predicate"
+import { SelectQueryBuilder } from "./queryBuilder"
+import { selectionToIncludeData } from "./selection"
+
+describe("SelectQueryBuilder", () => {
+  let mockClient: ArkivClient
+  let mockProcessQuery: any
+
+  beforeEach(() => {
+    mockClient = {
+      request: jest.fn(),
+    } as unknown as ArkivClient
+
+    mockProcessQuery = jest.spyOn(engine, "processQuery")
+    jest.spyOn(entitiesUtils, "entityFromRpcResult")
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test("select() with no argument forwards include-data for everything", async () => {
+    mockProcessQuery.mockResolvedValue({ data: [] })
+
+    await new SelectQueryBuilder(mockClient).where(eq("name", "test")).fetch()
+
+    expect(mockProcessQuery).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({
+        predicates: [eq("name", "test")],
+        includeData: selectionToIncludeData(),
+      }),
+    )
+  })
+
+  test('select("*") forwards include-data for everything', async () => {
+    mockProcessQuery.mockResolvedValue({ data: [] })
+
+    await new SelectQueryBuilder(mockClient, "*").fetch()
+
+    expect(mockProcessQuery).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({
+        includeData: selectionToIncludeData("*"),
+      }),
+    )
+  })
+
+  test("select({ owner: true, attributes: true }) forwards the resolved include-data", async () => {
+    mockProcessQuery.mockResolvedValue({ data: [] })
+
+    await new SelectQueryBuilder(mockClient, { owner: true, attributes: true }).fetch()
+
+    expect(mockProcessQuery).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({
+        includeData: selectionToIncludeData({ owner: true, attributes: true }),
+      }),
+    )
+  })
+
+  test("select({ owner: true }) forwards narrowed include-data", async () => {
+    mockProcessQuery.mockResolvedValue({ data: [] })
+
+    await new SelectQueryBuilder(mockClient, { owner: true }).fetch()
+
+    const call = mockProcessQuery.mock.calls[0][1]
+    expect(call.includeData).toEqual(selectionToIncludeData({ owner: true }))
+    expect(call.includeData.owner).toBe(true)
+    expect(call.includeData.creator).toBe(false)
+    // key is opt-in: not selected here, so it is excluded
+    expect(call.includeData.key).toBe(false)
+  })
+
+  test("does not forward the with* boolean flags", async () => {
+    mockProcessQuery.mockResolvedValue({ data: [] })
+
+    await new SelectQueryBuilder(mockClient, { attributes: true }).fetch()
+
+    const call = mockProcessQuery.mock.calls[0][1]
+    expect(call.withAttributes).toBeUndefined()
+    expect(call.withMetadata).toBeUndefined()
+    expect(call.withPayload).toBeUndefined()
+  })
+
+  test("shares the filtering/ordering/pagination chain methods", async () => {
+    mockProcessQuery.mockResolvedValue({ data: [] })
+
+    const owner = "0x1234567890123456789012345678901234567890" as const
+    await new SelectQueryBuilder(mockClient, { attributes: true })
+      .where(eq("name", "test"))
+      .where(gte("age", 18))
+      .ownedBy(owner)
+      .createdBy(owner)
+      .orderBy("name", "string", "desc")
+      .limit(10)
+      .cursor("0xABC123")
+      .validAtBlock(123n)
+      .fetch()
+
+    expect(mockProcessQuery).toHaveBeenCalledWith(mockClient, {
+      predicates: [eq("name", "test"), gte("age", 18)],
+      limit: 10,
+      cursor: "0xABC123",
+      ownedBy: owner,
+      createdBy: owner,
+      orderBy: [{ name: "name", type: "string", desc: true }],
+      validAtBlock: 123n,
+      includeData: selectionToIncludeData({ attributes: true }),
+    })
+  })
+
+  test("count() ignores the selection and requests no data", async () => {
+    mockProcessQuery.mockResolvedValue({
+      data: [
+        { key: "0xabc", value: "data1" },
+        { key: "0xdef", value: "data2" },
+      ],
+    })
+
+    const count = await new SelectQueryBuilder(mockClient, "*")
+      .where(eq("status", "active"))
+      .count()
+
+    expect(count).toBe(2)
+    expect(mockProcessQuery).toHaveBeenCalledWith(mockClient, {
+      predicates: [eq("status", "active")],
+      limit: undefined,
+      cursor: undefined,
+      ownedBy: undefined,
+      createdBy: undefined,
+      orderBy: undefined,
+      validAtBlock: undefined,
+      withAttributes: false,
+      withMetadata: false,
+      withPayload: false,
+    })
+  })
+
+  describe("result entities", () => {
+    test("fetch returns flat Entity instances with the selected data and methods", async () => {
+      mockProcessQuery.mockResolvedValue({
+        data: [
+          {
+            key: "0xabc",
+            owner: "0xowner",
+            value: "0x68656c6c6f", // "hello"
+            stringAttributes: [{ key: "category", value: "docs" }],
+            numericAttributes: [{ key: "score", value: "0x2a" }],
+          },
+        ],
+        cursor: "",
+        blockNumber: "0x1",
+      })
+
+      const result = await new SelectQueryBuilder(mockClient, {
+        key: true,
+        owner: true,
+        attributes: true,
+        payload: true,
+      }).fetch()
+
+      expect(result.entities).toHaveLength(1)
+      const entity = result.entities[0] as unknown as Entity
+      // flat, backwards-compatible field access
+      expect(entity.key).toBe("0xabc")
+      expect(entity.owner).toBe("0xowner")
+      expect(entity.attributes).toEqual([
+        { key: "category", value: "docs" },
+        { key: "score", value: 42 },
+      ])
+      // entity methods are preserved on the result
+      expect(typeof entity.toText).toBe("function")
+      expect(entity.toText()).toBe("hello")
+    })
+
+    test("toJson decodes a JSON payload", async () => {
+      mockProcessQuery.mockResolvedValue({
+        data: [{ key: "0xabc", value: "0x7b2261223a317d" }], // {"a":1}
+        cursor: "",
+        blockNumber: "0x1",
+      })
+
+      const result = await new SelectQueryBuilder(mockClient, { payload: true }).fetch()
+      const entity = result.entities[0] as unknown as Entity
+      expect(entity.toJson()).toEqual({ a: 1 })
+    })
+
+    test("fields the RPC omits (because they were not selected) are undefined at runtime", async () => {
+      // The RPC honours includeData and returns only the key.
+      mockProcessQuery.mockResolvedValue({
+        data: [{ key: "0xabc" }],
+        cursor: "",
+        blockNumber: "0x1",
+      })
+
+      const result = await new SelectQueryBuilder(mockClient, { key: true }).fetch()
+      const entity = result.entities[0] as unknown as Entity
+      expect(entity.key).toBe("0xabc")
+      expect(entity.owner).toBeUndefined()
+      expect(entity.payload).toBeUndefined()
+      expect(entity.attributes).toEqual([])
+    })
+  })
+})

--- a/src/query/selection.test.ts
+++ b/src/query/selection.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test"
+import { selectionToIncludeData } from "./selection"
+
+const ALL = {
+  key: true,
+  attributes: true,
+  payload: true,
+  contentType: true,
+  expiration: true,
+  owner: true,
+  creator: true,
+  createdAtBlock: true,
+  lastModifiedAtBlock: true,
+  transactionIndexInBlock: true,
+  operationIndexInTransaction: true,
+}
+
+const EMPTY = {
+  key: false,
+  attributes: false,
+  payload: false,
+  contentType: false,
+  expiration: false,
+  owner: false,
+  creator: false,
+  createdAtBlock: false,
+  lastModifiedAtBlock: false,
+  transactionIndexInBlock: false,
+  operationIndexInTransaction: false,
+}
+
+describe("selectionToIncludeData", () => {
+  test("select() with no argument selects everything", () => {
+    expect(selectionToIncludeData()).toEqual(ALL)
+  })
+
+  test('select("*") selects everything', () => {
+    expect(selectionToIncludeData("*")).toEqual(ALL)
+  })
+
+  test("empty object throws", () => {
+    // @ts-expect-error – select requires at least one field
+    expect(() => selectionToIncludeData({})).toThrow()
+  })
+
+  test("an all-false selection throws (no field is actually selected)", () => {
+    expect(() => selectionToIncludeData({ key: false })).toThrow()
+    expect(() => selectionToIncludeData({ owner: false, payload: false })).toThrow()
+  })
+
+  test("key: true selects only the key", () => {
+    expect(selectionToIncludeData({ key: true })).toEqual({ ...EMPTY, key: true })
+  })
+
+  test("key is opt-in like every other field", () => {
+    expect(selectionToIncludeData({ key: true }).key).toBe(true)
+    expect(selectionToIncludeData({ attributes: true }).key).toBe(false)
+    expect(selectionToIncludeData({ owner: true }).key).toBe(false)
+  })
+
+  test("attributes only (no key)", () => {
+    expect(selectionToIncludeData({ attributes: true })).toEqual({
+      ...EMPTY,
+      attributes: true,
+    })
+  })
+
+  test("payload only (no key)", () => {
+    expect(selectionToIncludeData({ payload: true })).toEqual({
+      ...EMPTY,
+      payload: true,
+    })
+  })
+
+  test("a single metadata field, selected flat (no key)", () => {
+    expect(selectionToIncludeData({ owner: true })).toEqual({
+      ...EMPTY,
+      owner: true,
+    })
+  })
+
+  test("expiresAtBlock maps to the RPC `expiration` field", () => {
+    expect(selectionToIncludeData({ expiresAtBlock: true })).toEqual({
+      ...EMPTY,
+      expiration: true,
+    })
+  })
+
+  test("several fields selected together", () => {
+    expect(
+      selectionToIncludeData({
+        owner: true,
+        creator: true,
+        createdAtBlock: true,
+        attributes: true,
+      }),
+    ).toEqual({
+      ...EMPTY,
+      owner: true,
+      creator: true,
+      createdAtBlock: true,
+      attributes: true,
+    })
+  })
+
+  test("key can be combined with other fields", () => {
+    expect(selectionToIncludeData({ key: true, attributes: true })).toEqual({
+      ...EMPTY,
+      key: true,
+      attributes: true,
+    })
+  })
+
+  test("a field set to false is not selected", () => {
+    expect(selectionToIncludeData({ owner: true, creator: false })).toEqual({
+      ...EMPTY,
+      owner: true,
+    })
+  })
+})

--- a/src/query/selection.ts
+++ b/src/query/selection.ts
@@ -1,0 +1,116 @@
+import type { Entity } from "../types/entity"
+import type { RpcIncludeData } from "../types/rpcSchema"
+
+/** The entity fields that can be selected. These match the fields of {@link Entity} one-to-one. */
+type DataKey =
+  | "key"
+  | "contentType"
+  | "owner"
+  | "creator"
+  | "expiresAtBlock"
+  | "createdAtBlock"
+  | "lastModifiedAtBlock"
+  | "transactionIndexInBlock"
+  | "operationIndexInTransaction"
+  | "attributes"
+  | "payload"
+
+/**
+ * The parts of an entity that can be selected. Every field is opt-in (including the `key`) and maps
+ * directly to a field of the returned {@link Entity} — the selection is flat.
+ */
+export type SelectionFields = { [K in DataKey]?: boolean }
+
+/**
+ * Requires at least one property of `T` to be present.
+ * `{}` is not assignable, which is how `select({})` is rejected at compile time.
+ */
+type AtLeastOne<T, K extends keyof T = keyof T> = {
+  [P in K]: Required<Pick<T, P>> & Partial<Omit<T, P>>
+}[K]
+
+/**
+ * A non-empty entity selection — the object form accepted by `select()`. At least one field must be
+ * selected.
+ */
+export type EntitySelection = AtLeastOne<SelectionFields>
+
+/** Argument accepted by `select()` — a non-empty {@link EntitySelection}, or `"*"` for everything. */
+export type SelectArg = EntitySelection | "*"
+
+/**
+ * The result of a selection `S`: an {@link Entity} narrowed to exactly the selected fields (each
+ * non-`undefined`). The shape is flat and backwards compatible — e.g. `select({ owner: true })`
+ * yields `{ owner: Hex }` accessed as `entity.owner`. Accessing an unselected field is a compile
+ * error.
+ *
+ * The `toText()` / `toJson()` helpers operate on the payload, so they are only present when
+ * `payload` was selected — calling them otherwise would always throw.
+ */
+export type ProjectedEntity<S> = {
+  readonly [K in keyof S as S[K] extends true ? K : never]: K extends keyof Entity
+    ? NonNullable<Entity[K]>
+    : never
+} & (S extends { payload: true } ? Pick<Entity, "toText" | "toJson"> : unknown)
+
+/** A selection of every field, used to type the result of `select()` / `select("*")`. */
+type AllSelected = { [K in DataKey]: true }
+
+/** The projected entity type when everything is selected — every field, plus the methods. */
+export type FullEntity = ProjectedEntity<AllSelected>
+
+/**
+ * Converts a {@link SelectArg} into the {@link RpcIncludeData} understood by the query engine.
+ * Every field is opt-in — anything not explicitly selected defaults to `false`, including the key.
+ * `undefined` or `"*"` selects everything.
+ *
+ * @param selection - The selection to convert
+ * @returns The fully-resolved include-data object for the RPC query
+ * @throws If an empty selection object is provided
+ *
+ * @example
+ * selectionToIncludeData() // everything
+ * selectionToIncludeData("*") // everything
+ * selectionToIncludeData({ key: true }) // only the key
+ * selectionToIncludeData({ owner: true }) // only the owner
+ */
+export function selectionToIncludeData(selection?: SelectArg): RpcIncludeData {
+  if (selection === undefined || selection === "*") {
+    return {
+      key: true,
+      attributes: true,
+      payload: true,
+      contentType: true,
+      expiration: true,
+      owner: true,
+      creator: true,
+      createdAtBlock: true,
+      lastModifiedAtBlock: true,
+      transactionIndexInBlock: true,
+      operationIndexInTransaction: true,
+    }
+  }
+
+  // At least one field must be opted in. This rejects both `{}` and selections whose fields are
+  // all explicitly `false` (e.g. `select({ key: false })`), which the type system permits.
+  if (!Object.values(selection).some((selected) => selected === true)) {
+    throw new Error(
+      'select() requires at least one field to be selected. Pass select() or select("*") to select everything.',
+    )
+  }
+
+  return {
+    key: selection.key ?? false,
+    attributes: selection.attributes ?? false,
+    payload: selection.payload ?? false,
+    contentType: selection.contentType ?? false,
+    // The selection uses the entity field name `expiresAtBlock`; the RPC calls it `expiration`.
+    expiration: selection.expiresAtBlock ?? false,
+    owner: selection.owner ?? false,
+    creator: selection.creator ?? false,
+    createdAtBlock: selection.createdAtBlock ?? false,
+    lastModifiedAtBlock: selection.lastModifiedAtBlock ?? false,
+    transactionIndexInBlock: selection.transactionIndexInBlock ?? false,
+    operationIndexInTransaction: selection.operationIndexInTransaction ?? false,
+  }
+}

--- a/test/src/arkiv.test.ts
+++ b/test/src/arkiv.test.ts
@@ -11,6 +11,18 @@ import { execCommand, launchLocalArkivNode } from "./utils.js"
 
 const basicCRUDTestTimeout: number = parseInt(process.env.ARKIV_SDK_TEST_CRUD_TIMEOUT || "20000")
 
+// All metadata fields, selected flat (there is no `metadata` grouping).
+const allMetadata = {
+  contentType: true,
+  owner: true,
+  creator: true,
+  expiresAtBlock: true,
+  createdAtBlock: true,
+  lastModifiedAtBlock: true,
+  transactionIndexInBlock: true,
+  operationIndexInTransaction: true,
+} as const
+
 describe("Arkiv Integration Tests for public client", () => {
   let arkivNode: StartedTestContainer | undefined
   let publicClient: PublicArkivClient
@@ -214,7 +226,7 @@ describe("Arkiv Integration Tests for public client", () => {
     expect(testKey).toBeDefined()
 
     // build query
-    const query = client.buildQuery()
+    const query = client.select({ key: true })
     const entities = await query
       .where(eq("key", "value"))
       .ownedBy(privateKeyToAccount(privateKey).address)
@@ -250,7 +262,7 @@ describe("Arkiv Integration Tests for public client", () => {
 
     // query at specific block
     const queryAtBlock = await client
-      .buildQuery()
+      .select({ key: true })
       .where(eq("key", "value"))
       .validAtBlock(1n)
       .fetch()
@@ -287,7 +299,7 @@ describe("Arkiv Integration Tests for public client", () => {
 
       // query using the createdBy filter (maps to $creator)
       const queryResult = await readClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("createdByTestKey", "createdByTestValue"))
         .createdBy(creatorAddress)
         .fetch()
@@ -296,7 +308,7 @@ describe("Arkiv Integration Tests for public client", () => {
 
       // query combining both ownedBy and createdBy
       const combinedResult = await readClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("createdByTestKey", "createdByTestValue"))
         .ownedBy(creatorAddress)
         .createdBy(creatorAddress)
@@ -306,7 +318,7 @@ describe("Arkiv Integration Tests for public client", () => {
 
       // query with a non-matching creator should return no results
       const noResults = await readClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("createdByTestKey", "createdByTestValue"))
         .createdBy("0x0000000000000000000000000000000000000000")
         .fetch()
@@ -326,16 +338,19 @@ describe("Arkiv Integration Tests for public client", () => {
       expect(testKey).toBeDefined()
 
       // build query
-      const query = client.buildQuery()
+      const query = client.select(allMetadata)
       const entities = await query
         .where(eq("key", "value"))
         .ownedBy(privateKeyToAccount(privateKey).address)
-        .withMetadata()
         .fetch()
       expect(entities).toBeDefined()
       expect(entities.entities.length).toBeGreaterThanOrEqual(1)
+      // @ts-expect-error payload was not selected
       expect(entities.entities[0].payload).toBeUndefined()
-      expect(entities.entities[0].attributes).toBeArray()
+      // Attributes are absent from the projected type (compile error). At runtime, Entity always
+      // materializes attributes to an empty array rather than undefined.
+      // @ts-expect-error attributes were not selected
+      expect(entities.entities[0].attributes).toEqual([])
       expect(entities.entities[0].contentType).toBeDefined()
       expect(entities.entities[0].expiresAtBlock).toBeDefined()
       expect(entities.entities[0].createdAtBlock).toBeDefined()
@@ -592,7 +607,7 @@ describe("Arkiv Integration Tests for public client", () => {
       }
 
       // query with pagination - irregular number of entities (6,4)
-      const query = readClient.buildQuery()
+      const query = readClient.select({ key: true })
       const queryResult = await query
         .where(eq("testKey", value))
         .limit(6)
@@ -611,7 +626,7 @@ describe("Arkiv Integration Tests for public client", () => {
       await expect(queryResult.next()).rejects.toThrow()
 
       // query with pagination - irregular number of entities (5,5)
-      const query2 = readClient.buildQuery()
+      const query2 = readClient.select({ key: true })
       const queryResult2 = await query2
         .where(eq("testKey", value))
         .limit(5)
@@ -632,7 +647,7 @@ describe("Arkiv Integration Tests for public client", () => {
     { timeout: 60000 },
   )
   test.each(["http", "webSocket"] as const)(
-    "Query with various projections using withAttributes, withMetadata, withPayload",
+    "Query with various projections using select",
     async (transport) => {
       const writeClient = transport === "http" ? walletClient : walletClientWS
       const readClient = transport === "http" ? publicClient : publicClientWS
@@ -649,67 +664,81 @@ describe("Arkiv Integration Tests for public client", () => {
         expiresIn: ExpirationTime.fromBlocks(1000),
       })
 
-      // query with no data fetched - just key (it is always fetched)
-      let queryResult = await readClient.buildQuery().where(eq("testKey", "testValue")).fetch()
-      expect(queryResult).toBeDefined()
-      expect(queryResult.entities.length).toBeGreaterThanOrEqual(1)
-      expect(queryResult.entities[0].owner).toBeUndefined()
-      expect(queryResult.entities[0].creator).toBeUndefined()
-      expect(queryResult.entities[0].payload).toBeUndefined()
-      expect(queryResult.entities[0].attributes).toHaveLength(0)
-      expect(queryResult.entities[0].expiresAtBlock).toBeUndefined()
-      expect(queryResult.entities[0].createdAtBlock).toBeUndefined()
-      expect(queryResult.entities[0].lastModifiedAtBlock).toBeUndefined()
-      expect(queryResult.entities[0].transactionIndexInBlock).toBeUndefined()
-      expect(queryResult.entities[0].operationIndexInTransaction).toBeUndefined()
+      // query with just the key — the result type is narrowed to exactly { key }
+      const keyOnly = await readClient
+        .select({ key: true })
+        .where(eq("testKey", "testValue"))
+        .fetch()
+      expect(keyOnly.entities.length).toBeGreaterThanOrEqual(1)
+      expect(keyOnly.entities[0].key).toBeDefined()
+      // unselected fields are absent from the type (compile error) and undefined at runtime
+      // @ts-expect-error owner was not selected
+      expect(keyOnly.entities[0].owner).toBeUndefined()
+      // attributes are the exception: absent from the type, but Entity always materializes them
+      // to an empty array at runtime rather than undefined
+      // @ts-expect-error attributes were not selected
+      expect(keyOnly.entities[0].attributes).toEqual([])
+      // @ts-expect-error payload was not selected
+      expect(keyOnly.entities[0].payload).toBeUndefined()
+      // unselected metadata must actually be omitted by the RPC, not just typed out — this is the
+      // over-fetch guarantee select() exists to provide, so assert it at runtime
+      // @ts-expect-error contentType was not selected
+      expect(keyOnly.entities[0].contentType).toBeUndefined()
+      // @ts-expect-error creator was not selected
+      expect(keyOnly.entities[0].creator).toBeUndefined()
+      // @ts-expect-error expiresAtBlock was not selected
+      expect(keyOnly.entities[0].expiresAtBlock).toBeUndefined()
+      // @ts-expect-error createdAtBlock was not selected
+      expect(keyOnly.entities[0].createdAtBlock).toBeUndefined()
+      // @ts-expect-error lastModifiedAtBlock was not selected
+      expect(keyOnly.entities[0].lastModifiedAtBlock).toBeUndefined()
+      // @ts-expect-error transactionIndexInBlock was not selected
+      expect(keyOnly.entities[0].transactionIndexInBlock).toBeUndefined()
+      // @ts-expect-error operationIndexInTransaction was not selected
+      expect(keyOnly.entities[0].operationIndexInTransaction).toBeUndefined()
 
       // query with payload only
-      queryResult = await readClient
-        .buildQuery()
+      const payloadOnly = await readClient
+        .select({ payload: true })
         .where(eq("testKey", "testValue"))
-        .withAttributes(false)
-        .withMetadata(false)
-        .withPayload(true)
         .fetch()
-      expect(queryResult).toBeDefined()
-      expect(queryResult.entities.length).toBeGreaterThanOrEqual(1)
-      expect(queryResult.entities[0].payload?.length).toBeGreaterThan(0)
+      expect(payloadOnly.entities.length).toBeGreaterThanOrEqual(1)
+      expect(payloadOnly.entities[0].payload.length).toBeGreaterThan(0)
 
-      // query with metadata only
-      queryResult = await readClient
-        .buildQuery()
+      // query with metadata only — metadata fields are flattened onto the result
+      const metadataOnly = await readClient
+        .select(allMetadata)
         .where(eq("testKey", "testValue"))
-        .withAttributes(false)
-        .withMetadata(true)
-        .withPayload(false)
         .fetch()
+      expect(metadataOnly.entities.length).toBeGreaterThanOrEqual(1)
+      expect(metadataOnly.entities[0].owner).toBeDefined()
+      expect(metadataOnly.entities[0].creator).toBeDefined()
+      expect(metadataOnly.entities[0].contentType).toBeDefined()
+      expect(metadataOnly.entities[0].expiresAtBlock).toBeDefined()
+      expect(metadataOnly.entities[0].createdAtBlock).toBeDefined()
+      expect(metadataOnly.entities[0].lastModifiedAtBlock).toBeDefined()
+      expect(metadataOnly.entities[0].transactionIndexInBlock).toBeDefined()
+      expect(metadataOnly.entities[0].operationIndexInTransaction).toBeDefined()
 
-      expect(queryResult).toBeDefined()
-      expect(queryResult.entities.length).toBeGreaterThanOrEqual(1)
-      console.log("queryResult.entities[0]", queryResult.entities[0])
-      expect(queryResult.entities[0].owner).toBeDefined()
-      expect(queryResult.entities[0].creator).toBeDefined()
-      expect(queryResult.entities[0].expiresAtBlock).toBeDefined()
-      expect(queryResult.entities[0].createdAtBlock).toBeDefined()
-      expect(queryResult.entities[0].lastModifiedAtBlock).toBeDefined()
-      expect(queryResult.entities[0].transactionIndexInBlock).toBeDefined()
-      expect(queryResult.entities[0].operationIndexInTransaction).toBeDefined()
-
-      // query with annotations only
-      queryResult = await readClient
-        .buildQuery()
+      // query with attributes only
+      const attributesOnly = await readClient
+        .select({ attributes: true })
         .where(eq("testKey", "testValue"))
-        .withAttributes(true)
-        .withMetadata(false)
-        .withPayload(false)
         .fetch()
-      expect(queryResult).toBeDefined()
-      expect(queryResult.entities[0].attributes.length).toBeGreaterThanOrEqual(1)
-      expect(queryResult.entities[0].createdAtBlock).toBeUndefined()
-      expect(queryResult.entities[0].lastModifiedAtBlock).toBeUndefined()
-      expect(queryResult.entities[0].transactionIndexInBlock).toBeUndefined()
-      expect(queryResult.entities[0].operationIndexInTransaction).toBeUndefined()
-      expect(queryResult.entities[0].payload).toBeUndefined()
+      expect(attributesOnly.entities[0].attributes.length).toBeGreaterThanOrEqual(1)
+      // @ts-expect-error owner was not selected
+      expect(attributesOnly.entities[0].owner).toBeUndefined()
+      // @ts-expect-error payload was not selected
+      expect(attributesOnly.entities[0].payload).toBeUndefined()
+      // unselected metadata is omitted by the RPC (over-fetch guarantee), not just typed out
+      // @ts-expect-error key was not selected
+      expect(attributesOnly.entities[0].key).toBeUndefined()
+      // @ts-expect-error creator was not selected
+      expect(attributesOnly.entities[0].creator).toBeUndefined()
+      // @ts-expect-error createdAtBlock was not selected
+      expect(attributesOnly.entities[0].createdAtBlock).toBeUndefined()
+      // @ts-expect-error operationIndexInTransaction was not selected
+      expect(attributesOnly.entities[0].operationIndexInTransaction).toBeUndefined()
     },
     { timeout: 20000 },
   )
@@ -768,11 +797,8 @@ describe("Arkiv Integration Tests for public client", () => {
       const tx = await readClient.getTransactionReceipt({ hash: txHash })
 
       const result = await readClient
-        .buildQuery()
+        .select({ ...allMetadata, attributes: true })
         .where(eq("$key", entityKey))
-        .withAttributes(true)
-        .withMetadata()
-        .withMetadata(true)
         .fetch()
 
       console.log("Entity attributes", result.entities[0].attributes)
@@ -825,11 +851,10 @@ describe("Arkiv Integration Tests for public client", () => {
       // Helper to read all with group=orderby-test
       const getEntities = async (orderDesc: boolean) => {
         const result = await readClient
-          .buildQuery()
+          .select({ attributes: true })
           .where([eq("group", "orderby-test"), eq("transport", transport)])
           .orderBy(orderDesc ? desc("score", "number") : asc("score", "number"))
           .orderBy(orderDesc ? desc("entityId", "string") : asc("entityId", "string"))
-          .withAttributes(true)
           .fetch()
 
         return result.entities.map((ent) => {

--- a/test/src/network-health.test.ts
+++ b/test/src/network-health.test.ts
@@ -103,11 +103,9 @@ describe(`Network health check (${chain.name})`, () => {
 
       // QUERY
       const queryResult = await publicClient
-        .buildQuery()
+        .select({ key: true, attributes: true, payload: true })
         .where(eq("tag", tag))
         .ownedBy(account.address)
-        .withPayload(true)
-        .withAttributes(true)
         .fetch();
 
       expect(queryResult.entities.length).toBe(1);
@@ -259,7 +257,10 @@ describe(`Network health check (${chain.name})`, () => {
       const { entityKey } = await walletClient.createEntity({
         payload: jsonToPayload({ ownershipTest: true }),
         contentType: "application/json",
-        attributes: [{ key: "purpose", value: "ownership_test" }, { key: "tag", value: tag }],
+        attributes: [
+          { key: "purpose", value: "ownership_test" },
+          { key: "tag", value: tag },
+        ],
         expiresIn: ExpirationTime.fromHours(1),
       });
 
@@ -267,11 +268,13 @@ describe(`Network health check (${chain.name})`, () => {
       const before = await publicClient.getEntity(entityKey);
       expect(before.owner?.toLowerCase()).toBe(account.address.toLowerCase());
       expect(before.creator?.toLowerCase()).toBe(account.address.toLowerCase());
-      console.log(`  OWNER   before=${before.owner}  creator=${before.creator}`);
+      console.log(
+        `  OWNER   before=${before.owner}  creator=${before.creator}`,
+      );
 
       // createdBy query should find the entity before transfer
       const createdByBefore = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .createdBy(account.address)
         .fetch();
@@ -293,7 +296,7 @@ describe(`Network health check (${chain.name})`, () => {
 
       // after ownership transfer, createdBy should still return the entity
       const createdByAfter = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .createdBy(account.address)
         .fetch();
@@ -303,16 +306,18 @@ describe(`Network health check (${chain.name})`, () => {
 
       // ownedBy with the original owner should no longer return the entity
       const ownedByOriginal = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .ownedBy(account.address)
         .fetch();
       expect(ownedByOriginal.entities.length).toBe(0);
-      console.log(`  QUERY   ownedBy original owner correctly returns 0 after transfer`);
+      console.log(
+        `  QUERY   ownedBy original owner correctly returns 0 after transfer`,
+      );
 
       // ownedBy with the new owner should return the entity
       const ownedByNew = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .ownedBy(newOwner)
         .fetch();
@@ -458,72 +463,64 @@ describe(`Network health check (${chain.name})`, () => {
 
       // eq – only score=30
       const eqResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), eq("score", 30)])
-        .withAttributes(true)
         .fetch();
       expect(eqResult.entities).toHaveLength(1);
       console.log(`  FILTER  eq: found ${eqResult.entities.length}`);
 
       // neq – everything except score=30 → 4 entities
       const neqResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), neq("score", 30)])
-        .withAttributes(true)
         .fetch();
       expect(neqResult.entities).toHaveLength(4);
       console.log(`  FILTER  neq: found ${neqResult.entities.length}`);
 
       // gt – score > 30 → 40, 50
       const gtResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), gt("score", 30)])
-        .withAttributes(true)
         .fetch();
       expect(gtResult.entities).toHaveLength(2);
       console.log(`  FILTER  gt: found ${gtResult.entities.length}`);
 
       // gte – score >= 30 → 30, 40, 50
       const gteResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), gte("score", 30)])
-        .withAttributes(true)
         .fetch();
       expect(gteResult.entities).toHaveLength(3);
       console.log(`  FILTER  gte: found ${gteResult.entities.length}`);
 
       // lt – score < 30 → 10, 20
       const ltResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), lt("score", 30)])
-        .withAttributes(true)
         .fetch();
       expect(ltResult.entities).toHaveLength(2);
       console.log(`  FILTER  lt: found ${ltResult.entities.length}`);
 
       // lte – score <= 30 → 10, 20, 30
       const lteResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), lte("score", 30)])
-        .withAttributes(true)
         .fetch();
       expect(lteResult.entities).toHaveLength(3);
       console.log(`  FILTER  lte: found ${lteResult.entities.length}`);
 
       // or – score=10 OR score=50 → 2
       const orResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), or([eq("score", 10), eq("score", 50)])])
-        .withAttributes(true)
         .fetch();
       expect(orResult.entities).toHaveLength(2);
       console.log(`  FILTER  or: found ${orResult.entities.length}`);
 
       // and – score > 10 AND score < 50 → 20, 30, 40
       const andResult = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where([eq("group", group), and([gt("score", 10), lt("score", 50)])])
-        .withAttributes(true)
         .fetch();
       expect(andResult.entities).toHaveLength(3);
       console.log(`  FILTER  and: found ${andResult.entities.length}`);
@@ -532,7 +529,7 @@ describe(`Network health check (${chain.name})`, () => {
   );
 
   test(
-    "query projections: withAttributes, withMetadata, withPayload",
+    "query projections via select",
     async () => {
       const tag = `proj-${Date.now()}`;
 
@@ -546,38 +543,52 @@ describe(`Network health check (${chain.name})`, () => {
         expiresIn: ExpirationTime.fromHours(1),
       });
 
-      // default (no projections) – only key
+      // key only – the result type is narrowed to exactly { key }
       const defaultResult = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .fetch();
       const e0 = defaultResult.entities[0];
       expect(e0.key).toBeDefined();
+      // @ts-expect-error payload was not selected
       expect(e0.payload).toBeUndefined();
-      expect(e0.attributes).toHaveLength(0);
-      expect(e0.expiresAtBlock).toBeUndefined();
-      console.log(`  PROJ    default: key-only`);
+      // attributes are absent from the type, but Entity always materializes them to an empty
+      // array at runtime rather than undefined
+      // @ts-expect-error attributes were not selected
+      expect(e0.attributes).toEqual([]);
+      // unselected metadata is omitted by the RPC at runtime, not just typed out (over-fetch guard)
+      // @ts-expect-error owner was not selected
+      expect(e0.owner).toBeUndefined();
+      // @ts-expect-error createdAtBlock was not selected
+      expect(e0.createdAtBlock).toBeUndefined();
+      // @ts-expect-error operationIndexInTransaction was not selected
+      expect(e0.operationIndexInTransaction).toBeUndefined();
+      console.log(`  PROJ    key-only`);
 
       // payload only
       const payloadOnly = await publicClient
-        .buildQuery()
+        .select({ payload: true })
         .where(eq("tag", tag))
-        .withPayload(true)
-        .withAttributes(false)
-        .withMetadata(false)
         .fetch();
       const e1 = payloadOnly.entities[0];
-      expect(e1.payload?.length).toBeGreaterThan(0);
-      expect(e1.expiresAtBlock).toBeUndefined();
+      expect(e1.payload.length).toBeGreaterThan(0);
+      // @ts-expect-error owner was not selected
+      expect(e1.owner).toBeUndefined();
       console.log(`  PROJ    payload-only`);
 
-      // metadata only
+      // metadata only – metadata fields are flattened onto the result
       const metadataOnly = await publicClient
-        .buildQuery()
+        .select({
+          contentType: true,
+          owner: true,
+          creator: true,
+          expiresAtBlock: true,
+          createdAtBlock: true,
+          lastModifiedAtBlock: true,
+          transactionIndexInBlock: true,
+          operationIndexInTransaction: true,
+        })
         .where(eq("tag", tag))
-        .withMetadata(true)
-        .withPayload(false)
-        .withAttributes(false)
         .fetch();
       const e2 = metadataOnly.entities[0];
       expect(e2.owner).toBeDefined();
@@ -585,33 +596,33 @@ describe(`Network health check (${chain.name})`, () => {
       expect(e2.expiresAtBlock).toBeDefined();
       expect(e2.createdAtBlock).toBeDefined();
       expect(e2.lastModifiedAtBlock).toBeDefined();
+      expect(e2.transactionIndexInBlock).toBeDefined();
+      expect(e2.operationIndexInTransaction).toBeDefined();
+      expect(e2.contentType).toBeDefined();
+      // @ts-expect-error payload was not selected
       expect(e2.payload).toBeUndefined();
       console.log(`  PROJ    metadata-only`);
 
       // attributes only
       const attrsOnly = await publicClient
-        .buildQuery()
+        .select({ attributes: true })
         .where(eq("tag", tag))
-        .withAttributes(true)
-        .withPayload(false)
-        .withMetadata(false)
         .fetch();
       const e3 = attrsOnly.entities[0];
       expect(e3.attributes.length).toBeGreaterThanOrEqual(1);
+      // @ts-expect-error payload was not selected
       expect(e3.payload).toBeUndefined();
-      expect(e3.expiresAtBlock).toBeUndefined();
+      // @ts-expect-error owner was not selected
+      expect(e3.owner).toBeUndefined();
       console.log(`  PROJ    attributes-only`);
 
       // all projections
       const allProjections = await publicClient
-        .buildQuery()
+        .select("*")
         .where(eq("tag", tag))
-        .withAttributes(true)
-        .withMetadata(true)
-        .withPayload(true)
         .fetch();
       const e4 = allProjections.entities[0];
-      expect(e4.payload?.length).toBeGreaterThan(0);
+      expect(e4.payload.length).toBeGreaterThan(0);
       expect(e4.attributes.length).toBeGreaterThanOrEqual(1);
       expect(e4.owner).toBeDefined();
       expect(e4.creator).toBeDefined();
@@ -638,7 +649,7 @@ describe(`Network health check (${chain.name})`, () => {
 
       // fetch page 1 (limit 3)
       const page1 = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("group", group))
         .limit(3)
         .fetch();
@@ -678,7 +689,7 @@ describe(`Network health check (${chain.name})`, () => {
 
       // query with correct owner
       const ownedResult = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .ownedBy(account.address)
         .fetch();
@@ -691,7 +702,7 @@ describe(`Network health check (${chain.name})`, () => {
       // query with wrong owner – should find nothing
       const wrongOwner = "0x0000000000000000000000000000000000000001" as Hex;
       const notOwnedResult = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where(eq("tag", tag))
         .ownedBy(wrongOwner)
         .fetch();
@@ -733,7 +744,7 @@ describe(`Network health check (${chain.name})`, () => {
 
       // query by numeric attribute
       const numQuery = await publicClient
-        .buildQuery()
+        .select({ key: true })
         .where([eq("tag", tag), eq("numAttr", 42)])
         .fetch();
       expect(numQuery.entities).toHaveLength(1);

--- a/typedoc.json
+++ b/typedoc.json
@@ -15,6 +15,7 @@
   "excludeProtected": true,
   "excludeInternal": true,
   "excludeExternals": true,
+  "intentionallyNotExported": ["AtLeastOne", "DataKey", "AllSelected"],
   "theme": "default",
   "outputs": [
     {


### PR DESCRIPTION
Using `select` instead of `buildQuery` allows you to pick which fields of an entity you want to fetch and the resulting typescript type only exposes those fields (preventing you from accidentally accessing a field that was not included):

```ts
const [entity] = (await publicClient.select({ owner: true, payload: true }).fetch()).entities;
entity.owner;     // ✅ Hex
entity.toJson();  // ✅ payload was selected
entity.creator;   // ❌ compile error — not selected
```