### PR TITLE
Patch entity

### DIFF
--- a/src/actions/wallet/mutateEntities.test.ts
+++ b/src/actions/wallet/mutateEntities.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import type { ArkivClient } from "../../clients/baseClient"
+import { mutateEntities } from "./mutateEntities"
+
+test("throws when no operations are provided", () => {
+  expect(mutateEntities({} as ArkivClient, {})).rejects.toThrowError("No operations to perform")
+})
+
+test("throws when all operation arrays are empty", () => {
+  expect(
+    mutateEntities({} as ArkivClient, { creates: [], updates: [], patches: [], deletes: [] }),
+  ).rejects.toThrowError("No operations to perform")
+})

--- a/src/actions/wallet/mutateEntities.ts
+++ b/src/actions/wallet/mutateEntities.ts
@@ -16,7 +16,9 @@ import type { UpdateEntityParameters } from "./updateEntity"
 /**
  * Parameters for the mutateEntities function.
  * - creates: The creates to perform.
- * - updates: The updates to perform.
+ * - updates: The updates to perform. Each update is a **full replace**, not a
+ *   patch: the entity's new state is exactly the update's parameters (see
+ *   updateEntity).
  * - patches: The patches to perform. Each patch is resolved into a full update
  *   by fetching the entity's current state first (see patchEntity). Several
  *   patches for the same entity key are applied in order and folded into a

--- a/src/actions/wallet/mutateEntities.ts
+++ b/src/actions/wallet/mutateEntities.ts
@@ -10,18 +10,27 @@ const logger = getLogger("actions:wallet:mutate-entities")
 import type { CreateEntityParameters } from "./createEntity"
 import type { DeleteEntityParameters } from "./deleteEntity"
 import type { ExtendEntityParameters } from "./extendEntity"
+import { type PatchEntityParameters, resolvePatches } from "./patchEntity"
 import type { UpdateEntityParameters } from "./updateEntity"
 
 /**
  * Parameters for the mutateEntities function.
  * - creates: The creates to perform.
  * - updates: The updates to perform.
+ * - patches: The patches to perform. Each patch is resolved into a full update
+ *   by fetching the entity's current state first (see patchEntity). Several
+ *   patches for the same entity key are applied in order and folded into a
+ *   single update, each one seeing the previous one's changes. **Patches are
+ *   not atomic**: changes made to an entity between that read and the
+ *   mutation transaction landing on chain are silently overwritten and lost.
+ *   Patched entity keys are reported in updatedEntities (once per entity).
  * - deletes: The deletes to perform.
  * - extensions: The extensions to perform.
  */
 export type MutateEntitiesParameters = {
   creates?: CreateEntityParameters[]
   updates?: UpdateEntityParameters[]
+  patches?: PatchEntityParameters[]
   deletes?: DeleteEntityParameters[]
   extensions?: ExtendEntityParameters[]
   ownershipChanges?: ChangeOwnershipParameters[]
@@ -64,7 +73,7 @@ function parseReceipt(receipt: TransactionReceipt, params: MutateEntitiesParamet
  * Return type for the mutateEntities function.
  * - txHash: The transaction hash.
  * - createdEntities: The keys of the created entities.
- * - updatedEntities: The keys of the updated entities.
+ * - updatedEntities: The keys of the updated entities (including patched ones).
  * - deletedEntities: The keys of the deleted entities.
  * - extendedEntities: The keys of the extended entities.
  * - ownershipChanges: The keys of the ownership changes.
@@ -82,13 +91,23 @@ export async function mutateEntities(
   data: MutateEntitiesParameters,
   txParams?: TxParams,
 ): Promise<MutateEntitiesReturnType> {
-  if (!data.creates && !data.updates && !data.deletes && !data.extensions) {
+  const operationCount =
+    (data.creates?.length ?? 0) +
+    (data.updates?.length ?? 0) +
+    (data.patches?.length ?? 0) +
+    (data.deletes?.length ?? 0) +
+    (data.extensions?.length ?? 0) +
+    (data.ownershipChanges?.length ?? 0)
+  if (operationCount === 0) {
     throw new Error("No operations to perform")
   }
 
+  const resolvedPatches = await resolvePatches(client, data.patches ?? [])
+  const updates = [...(data.updates ?? []), ...resolvedPatches]
+
   const txData = opsToTxData({
     creates: data.creates ?? [],
-    updates: data.updates ?? [],
+    updates,
     deletes: data.deletes ?? [],
     extensions: data.extensions ?? [],
     ownershipChanges: data.ownershipChanges ?? [],
@@ -99,7 +118,7 @@ export async function mutateEntities(
   logger("Receipt from mutateEntities %o", receipt)
 
   const { createdEntities, updatedEntities, deletedEntities, extendedEntities, ownershipChanges } =
-    parseReceipt(receipt, data)
+    parseReceipt(receipt, { ...data, updates })
   return {
     txHash: receipt.transactionHash as Hash,
     createdEntities,

--- a/src/actions/wallet/patchEntity.test.ts
+++ b/src/actions/wallet/patchEntity.test.ts
@@ -1,0 +1,335 @@
+import { expect, test, vi } from "bun:test"
+import { toBytes, toHex } from "viem"
+import type { ArkivClient } from "../../clients/baseClient"
+import { CannotPreserveExpirationError, UnsafeNumericAttributeError } from "../../errors"
+import { resolvePatchEntities, resolvePatchEntity, resolvePatches } from "./patchEntity"
+
+const ENTITY_KEY = `0x${"11".repeat(32)}` as const
+
+// entity at block 40 that expires at block 100 with a text payload,
+// two string attributes and one numeric attribute
+function mockClient({
+  currentBlock = 40,
+  // null means the entity has no expiration block (undefined would trigger
+  // the default parameter value instead)
+  expiresAt = "0x64" as string | null,
+  stringAttributes = [
+    { key: "keep", value: "kept" },
+    { key: "replace", value: "old" },
+  ],
+  numericAttributes = [{ key: "num", value: "0x2a" }],
+} = {}) {
+  const request = vi.fn(async ({ method }: { method: string }) => {
+    if (method === "arkiv_query") {
+      return {
+        data: [
+          {
+            key: ENTITY_KEY,
+            contentType: "application/json",
+            value: toHex("old payload"),
+            expiresAt: expiresAt ?? undefined,
+            owner: ENTITY_KEY,
+            creator: ENTITY_KEY,
+            stringAttributes,
+            numericAttributes,
+          },
+        ],
+      }
+    }
+    if (method === "arkiv_getBlockTiming") {
+      return { current_block: currentBlock, current_block_time: 2, duration: 2 }
+    }
+    throw new Error(`unexpected method ${method}`)
+  })
+  return { client: { request } as unknown as ArkivClient, request }
+}
+
+test("keeps omitted fields from the current entity", async () => {
+  const { client } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    payload: toBytes("new payload"),
+  })
+
+  expect(update.entityKey).toEqual(ENTITY_KEY)
+  expect(update.payload).toEqual(toBytes("new payload"))
+  expect(update.contentType).toEqual("application/json")
+  expect(update.attributes).toEqual([
+    { key: "keep", value: "kept" },
+    { key: "replace", value: "old" },
+    { key: "num", value: 42 },
+  ])
+  // remaining lifetime preserved: (100 - 40) blocks * 2s
+  expect(update.expiresIn).toEqual(120)
+})
+
+test("keeps the current payload when only attributes are patched", async () => {
+  const { client } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [{ key: "added", value: "new" }],
+  })
+
+  expect(update.payload).toEqual(toBytes("old payload"))
+})
+
+test("merges attributes: appends new keys, replaces existing ones, keeps the rest", async () => {
+  const { client } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [
+      { key: "replace", value: "new" },
+      { key: "added", value: 1 },
+    ],
+  })
+
+  expect(update.attributes).toEqual([
+    { key: "keep", value: "kept" },
+    { key: "num", value: 42 },
+    { key: "replace", value: "new" },
+    { key: "added", value: 1 },
+  ])
+})
+
+test("removes an attribute when its value is null", async () => {
+  const { client } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [
+      { key: "replace", value: null },
+      { key: "added", value: "new" },
+    ],
+  })
+
+  expect(update.attributes).toEqual([
+    { key: "keep", value: "kept" },
+    { key: "num", value: 42 },
+    { key: "added", value: "new" },
+  ])
+})
+
+test("removing a non-existent attribute is a no-op", async () => {
+  const { client } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [{ key: "doesNotExist", value: null }],
+  })
+
+  expect(update.attributes).toEqual([
+    { key: "keep", value: "kept" },
+    { key: "replace", value: "old" },
+    { key: "num", value: 42 },
+  ])
+})
+
+test("replaces only the same-typed attribute when a key exists as both string and numeric", async () => {
+  const { client } = mockClient({
+    stringAttributes: [{ key: "v", value: "x" }],
+    numericAttributes: [{ key: "v", value: "0x7" }],
+  })
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [{ key: "v", value: 8 }],
+  })
+
+  expect(update.attributes).toEqual([
+    { key: "v", value: "x" },
+    { key: "v", value: 8 },
+  ])
+})
+
+test("a null value removes both the string and the numeric attribute with that key", async () => {
+  const { client } = mockClient({
+    stringAttributes: [
+      { key: "keep", value: "kept" },
+      { key: "v", value: "x" },
+    ],
+    numericAttributes: [{ key: "v", value: "0x7" }],
+  })
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [{ key: "v", value: null }],
+  })
+
+  expect(update.attributes).toEqual([{ key: "keep", value: "kept" }])
+})
+
+test("the last patch entry wins for duplicate keys of the same value type", async () => {
+  const { client } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [
+      { key: "status", value: "a" },
+      { key: "status", value: "b" },
+    ],
+  })
+
+  expect(update.attributes).toEqual([
+    { key: "keep", value: "kept" },
+    { key: "replace", value: "old" },
+    { key: "num", value: 42 },
+    { key: "status", value: "b" },
+  ])
+})
+
+test("a removal followed by a set re-adds only the set value type", async () => {
+  const { client } = mockClient({
+    stringAttributes: [{ key: "v", value: "x" }],
+    numericAttributes: [{ key: "v", value: "0x7" }],
+  })
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [
+      { key: "v", value: null },
+      { key: "v", value: 8 },
+    ],
+  })
+
+  expect(update.attributes).toEqual([{ key: "v", value: 8 }])
+})
+
+test("throws when an untouched numeric attribute exceeds Number.MAX_SAFE_INTEGER", async () => {
+  const { client } = mockClient({
+    // 2^63 - 1: Number() loses precision reading this back
+    numericAttributes: [{ key: "big", value: "0x7fffffffffffffff" }],
+  })
+  expect(
+    resolvePatchEntity(client, {
+      entityKey: ENTITY_KEY,
+      payload: toBytes("new payload"),
+    }),
+  ).rejects.toThrowError(UnsafeNumericAttributeError)
+})
+
+test("allows patching when the unsafe numeric attribute is overwritten or removed", async () => {
+  const { client } = mockClient({
+    numericAttributes: [{ key: "big", value: "0x7fffffffffffffff" }],
+  })
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    attributes: [{ key: "big", value: 1 }],
+  })
+  expect(update.attributes).toContainEqual({ key: "big", value: 1 })
+
+  const { client: client2 } = mockClient({
+    numericAttributes: [{ key: "big", value: "0x7fffffffffffffff" }],
+  })
+  const removed = await resolvePatchEntities(client2, [
+    { entityKey: ENTITY_KEY, attributes: [{ key: "big", value: null }] },
+  ])
+  expect(removed.attributes).not.toContainEqual({ key: "big", value: expect.anything() })
+})
+
+test("uses the provided expiresIn without fetching block timing", async () => {
+  const { client, request } = mockClient()
+  const update = await resolvePatchEntity(client, {
+    entityKey: ENTITY_KEY,
+    expiresIn: 1000,
+  })
+
+  expect(update.expiresIn).toEqual(1000)
+  const methods = request.mock.calls.map(([{ method }]) => method)
+  expect(methods).not.toContain("arkiv_getBlockTiming")
+})
+
+test("throws when expiresIn is omitted and the entity has already expired", async () => {
+  const { client } = mockClient({ currentBlock: 100 })
+  expect(
+    resolvePatchEntity(client, {
+      entityKey: ENTITY_KEY,
+      payload: toBytes("new payload"),
+    }),
+  ).rejects.toThrowError(CannotPreserveExpirationError)
+})
+
+test("throws when expiresIn is omitted and the entity has no expiration block", async () => {
+  const { client } = mockClient({ expiresAt: null })
+  expect(
+    resolvePatchEntity(client, {
+      entityKey: ENTITY_KEY,
+      payload: toBytes("new payload"),
+    }),
+  ).rejects.toThrowError(CannotPreserveExpirationError)
+})
+
+test("folds several patches for the same entity, later patches seeing earlier changes", async () => {
+  const { client, request } = mockClient()
+  const update = await resolvePatchEntities(client, [
+    {
+      entityKey: ENTITY_KEY,
+      attributes: [
+        { key: "a", value: 1 },
+        { key: "replace", value: "first" },
+      ],
+    },
+    {
+      entityKey: ENTITY_KEY,
+      payload: toBytes("second payload"),
+      attributes: [{ key: "replace", value: "second" }],
+    },
+  ])
+
+  // both patches applied, the second overriding the first where they overlap
+  expect(update.payload).toEqual(toBytes("second payload"))
+  expect(update.attributes).toEqual([
+    { key: "keep", value: "kept" },
+    { key: "num", value: 42 },
+    { key: "a", value: 1 },
+    { key: "replace", value: "second" },
+  ])
+  // the entity is only read once for the whole group
+  const methods = request.mock.calls.map(([{ method }]) => method)
+  expect(methods.filter((method) => method === "arkiv_query")).toHaveLength(1)
+})
+
+test("the last patch that sets expiresIn wins for a folded group", async () => {
+  const { client, request } = mockClient()
+  const update = await resolvePatchEntities(client, [
+    { entityKey: ENTITY_KEY, expiresIn: 1000 },
+    { entityKey: ENTITY_KEY, attributes: [{ key: "a", value: 1 }] },
+  ])
+
+  expect(update.expiresIn).toEqual(1000)
+  const methods = request.mock.calls.map(([{ method }]) => method)
+  expect(methods).not.toContain("arkiv_getBlockTiming")
+})
+
+test("uses the provided block timing instead of calling the client", async () => {
+  const { client, request } = mockClient()
+  const update = await resolvePatchEntities(
+    client,
+    [{ entityKey: ENTITY_KEY, payload: toBytes("new payload") }],
+    { currentBlock: 40n, currentBlockTime: 2, blockDuration: 2 },
+  )
+
+  expect(update.expiresIn).toEqual(120)
+  const methods = request.mock.calls.map(([{ method }]) => method)
+  expect(methods).not.toContain("arkiv_getBlockTiming")
+})
+
+test("resolvePatches fetches block timing once for several patched entities", async () => {
+  const { client, request } = mockClient()
+  const otherKey = `0x${"22".repeat(32)}` as const
+  const updates = await resolvePatches(client, [
+    { entityKey: ENTITY_KEY, attributes: [{ key: "a", value: 1 }] },
+    { entityKey: otherKey, attributes: [{ key: "b", value: 2 }] },
+  ])
+
+  expect(updates).toHaveLength(2)
+  const methods = request.mock.calls.map(([{ method }]) => method)
+  expect(methods.filter((method) => method === "arkiv_query")).toHaveLength(2)
+  expect(methods.filter((method) => method === "arkiv_getBlockTiming")).toHaveLength(1)
+})
+
+test("resolvePatches skips block timing when every entity's patches set expiresIn", async () => {
+  const { client, request } = mockClient()
+  const updates = await resolvePatches(client, [
+    { entityKey: ENTITY_KEY, attributes: [{ key: "a", value: 1 }] },
+    { entityKey: ENTITY_KEY, expiresIn: 1000 },
+  ])
+
+  expect(updates).toHaveLength(1)
+  expect(updates[0].expiresIn).toEqual(1000)
+  const methods = request.mock.calls.map(([{ method }]) => method)
+  expect(methods).not.toContain("arkiv_getBlockTiming")
+})

--- a/src/actions/wallet/patchEntity.ts
+++ b/src/actions/wallet/patchEntity.ts
@@ -1,0 +1,273 @@
+import type { Hash, Hex } from "viem"
+import type { ArkivClient } from "../../clients/baseClient"
+import { BLOCK_TIME } from "../../consts"
+import { CannotPreserveExpirationError, UnsafeNumericAttributeError } from "../../errors"
+import type { Attribute, MimeType, TxParams } from "../../types"
+import { getLogger } from "../../utils/logger"
+import { type GetBlockTimingReturnType, getBlockTiming } from "../public/getBlockTiming"
+import { getEntity } from "../public/getEntity"
+import { type UpdateEntityParameters, updateEntity } from "./updateEntity"
+
+const logger = getLogger("actions:wallet:patch-entity")
+
+/**
+ * An attribute in a patch (key/value pair). Unlike {@link Attribute}, the
+ * value may also be `null`, which removes the attribute from the entity
+ * instead of setting a value.
+ *
+ * Arkiv stores string and numeric attributes separately, so the same key may
+ * exist with both a string and a numeric value. A patch entry only replaces
+ * the existing attribute of the same value type; a `null` value removes both
+ * the string and the numeric attribute with that key. If a patch contains
+ * several entries with the same key and value type, the last one wins.
+ *
+ * Non-null values follow the same rules as {@link Attribute}: numeric values
+ * **must be integers** (scale non-integers, e.g. `1.5` -> `1500`, or use a
+ * string). A non-integer numeric value throws an {@link InvalidAttributeError}.
+ */
+export type PatchAttribute = {
+  key: string
+  /** Attribute value, or `null` to remove the attribute from the entity.
+   * A `number` must be an integer (scale non-integers, e.g. `1.5` -> `1500`, or
+   * use a string). Throws {@link InvalidAttributeError} otherwise. */
+  value: Attribute["value"] | null
+}
+
+/**
+ * Parameters for the patchEntity function. Every field except entityKey is
+ * optional — omitted fields keep the entity's current value.
+ * - entityKey: The key of the entity to patch.
+ * - payload: The new payload of the entity. If omitted, the current payload
+ *   is kept.
+ * - attributes: Attributes to merge into the entity's current attributes.
+ *   Attributes with new keys are appended; if a key already exists on the
+ *   entity with the same value type, its value is replaced; a value of `null`
+ *   removes both the string and the numeric attribute with that key. Existing
+ *   attributes not listed here are kept untouched. Attribute values may be
+ *   strings or numbers, but numeric values **must be integers**. To store a
+ *   non-integer, scale it to an integer (e.g. `1.5` -> `1500`) to preserve
+ *   numeric ordering, or pass it as a string (e.g. `"1.5"`). A non-integer
+ *   numeric value throws an {@link InvalidAttributeError}.
+ * - contentType: The new content type of the entity. If omitted, the current
+ *   content type is kept.
+ * - expiresIn: How long until the entity expires, in seconds. If omitted, the
+ *   entity's remaining lifetime is preserved as measured when the entity is
+ *   read back: each such patch can lengthen the lifetime by the blocks mined
+ *   until the update lands on chain, so pass expiresIn explicitly when the
+ *   exact expiration matters. Because Arkiv measures expiration in blocks
+ *   (1 block = 2 seconds), this **must be a positive integer and a multiple
+ *   of the block time (2 seconds)**. Invalid values throw an
+ *   {@link InvalidExpirationError}.
+ */
+export type PatchEntityParameters = {
+  entityKey: Hex
+  /** New payload. If omitted, the current payload is kept. */
+  payload?: Uint8Array
+  /** Attributes to merge with the entity's current attributes: new keys are appended,
+   * existing keys with the same value type have their value replaced, a `null` value
+   * removes both the string and the numeric attribute with that key, other attributes
+   * are kept. Numeric values must be integers (scale non-integers, e.g. `1.5` -> `1500`,
+   * or use a string). Throws {@link InvalidAttributeError} otherwise. */
+  attributes?: PatchAttribute[]
+  /** New content type. If omitted, the current content type is kept. */
+  contentType?: MimeType | string
+  /** Seconds until expiry. If omitted, the entity's remaining lifetime is preserved
+   * as measured at read time — each such patch can lengthen the lifetime by the
+   * blocks mined until the update lands, so pass expiresIn explicitly when the exact
+   * expiration matters. Must be a positive integer and a multiple of the 2s block
+   * time. Throws {@link InvalidExpirationError} otherwise. */
+  expiresIn?: number
+}
+
+/**
+ * Return type for the patchEntity function.
+ * - entityKey: The key of the entity.
+ * - txHash: The transaction hash.
+ */
+export type PatchEntityReturnType = {
+  entityKey: Hex
+  txHash: Hash
+}
+
+// String and numeric attributes live in separate spaces on chain, so patch
+// entries are indexed by (value type, key), not by key alone.
+function typedKey(type: "string" | "number", key: string): string {
+  return `${type}\0${key}`
+}
+
+/**
+ * Indexes patch entries by (value type, key). Later entries win over earlier
+ * ones with the same key and value type; a `null` value masks the key in both
+ * type spaces (a `null` entry maps to `null`, meaning removal).
+ */
+function patchToOps(patch: PatchAttribute[]): Map<string, Attribute | null> {
+  const ops = new Map<string, Attribute | null>()
+  for (const { key, value } of patch) {
+    if (value === null) {
+      ops.set(typedKey("string", key), null)
+      ops.set(typedKey("number", key), null)
+    } else {
+      ops.set(typedKey(typeof value === "number" ? "number" : "string", key), { key, value })
+    }
+  }
+  return ops
+}
+
+function mergeAttributes(existing: Attribute[], patch: PatchAttribute[]): Attribute[] {
+  const ops = patchToOps(patch)
+  return [
+    ...existing.filter(
+      (attribute) =>
+        !ops.has(
+          typedKey(typeof attribute.value === "number" ? "number" : "string", attribute.key),
+        ),
+    ),
+    ...[...ops.values()].filter((attribute): attribute is Attribute => attribute !== null),
+  ]
+}
+
+function applyPatchToUpdate(
+  base: UpdateEntityParameters,
+  patch: PatchEntityParameters,
+): UpdateEntityParameters {
+  return {
+    entityKey: base.entityKey,
+    payload: patch.payload ?? base.payload,
+    attributes: patch.attributes
+      ? mergeAttributes(base.attributes, patch.attributes)
+      : base.attributes,
+    contentType: patch.contentType ?? base.contentType,
+    expiresIn: patch.expiresIn ?? base.expiresIn,
+  }
+}
+
+/**
+ * Resolves an ordered list of patches targeting the **same entity** into full
+ * update parameters: the entity's current state is fetched once and the
+ * patches are applied on top of it in order, each one seeing the previous
+ * one's changes.
+ *
+ * When no patch sets expiresIn, the entity's remaining lifetime is computed
+ * from the current block (taken from blockTiming, which callers resolving
+ * several entities can fetch once and share; fetched from the client when not
+ * provided), so the resulting expiration matches the entity's current one up
+ * to the blocks mined until the update transaction lands.
+ */
+export async function resolvePatchEntities(
+  client: ArkivClient,
+  patches: PatchEntityParameters[],
+  blockTiming?: GetBlockTimingReturnType,
+): Promise<UpdateEntityParameters> {
+  const [{ entityKey }] = patches
+  const entity = await getEntity(client, entityKey)
+
+  // Numeric attributes are parsed with Number() when the entity is read back,
+  // so values above Number.MAX_SAFE_INTEGER may have lost precision and
+  // writing them back would silently corrupt them on chain. Refuse unless the
+  // patch overwrites or removes the affected attribute.
+  const ops = patchToOps(patches.flatMap((patch) => patch.attributes ?? []))
+  for (const attribute of entity.attributes) {
+    if (
+      typeof attribute.value === "number" &&
+      !Number.isSafeInteger(attribute.value) &&
+      !ops.has(typedKey("number", attribute.key))
+    ) {
+      throw new UnsafeNumericAttributeError(entityKey, attribute.key, attribute.value)
+    }
+  }
+
+  // the last patch that sets expiresIn wins; if none does, preserve the
+  // entity's remaining lifetime as measured now
+  let expiresIn: number | undefined
+  for (const patch of patches) {
+    expiresIn = patch.expiresIn ?? expiresIn
+  }
+  if (expiresIn === undefined) {
+    if (entity.expiresAtBlock === undefined) {
+      throw new CannotPreserveExpirationError(entityKey, "it has no expiration block.")
+    }
+    const { currentBlock } = blockTiming ?? (await getBlockTiming(client))
+    const remainingBlocks = entity.expiresAtBlock - currentBlock
+    if (remainingBlocks <= 0n) {
+      throw new CannotPreserveExpirationError(entityKey, "it has already expired.")
+    }
+    expiresIn = Number(remainingBlocks) * BLOCK_TIME
+  }
+
+  let update: UpdateEntityParameters = {
+    entityKey,
+    payload: entity.payload ?? new Uint8Array(),
+    attributes: entity.attributes,
+    contentType: entity.contentType ?? "",
+    expiresIn,
+  }
+  for (const patch of patches) {
+    update = applyPatchToUpdate(update, patch)
+  }
+  return update
+}
+
+/**
+ * Resolves a patch into full update parameters by fetching the entity's
+ * current state and overlaying the provided fields onto it.
+ *
+ * When expiresIn is omitted, the entity's remaining lifetime is computed from
+ * the current block, so the resulting expiration matches the entity's current
+ * one (up to the blocks mined until the update transaction lands).
+ */
+export async function resolvePatchEntity(
+  client: ArkivClient,
+  data: PatchEntityParameters,
+): Promise<UpdateEntityParameters> {
+  return await resolvePatchEntities(client, [data])
+}
+
+/**
+ * Resolves a list of patches, possibly targeting different entities, into
+ * full updates. Patches for the same entity key are grouped and applied in
+ * order, folding into a single update per entity so that none of them
+ * clobbers another. Block timing is fetched at most once, and only when a
+ * group needs it to preserve an entity's remaining lifetime.
+ */
+export async function resolvePatches(
+  client: ArkivClient,
+  patches: PatchEntityParameters[],
+): Promise<UpdateEntityParameters[]> {
+  const groups = new Map<Hex, PatchEntityParameters[]>()
+  for (const patch of patches) {
+    const group = groups.get(patch.entityKey)
+    if (group) group.push(patch)
+    else groups.set(patch.entityKey, [patch])
+  }
+
+  const needsBlockTiming = [...groups.values()].some((group) =>
+    group.every((patch) => patch.expiresIn === undefined),
+  )
+  const blockTiming = needsBlockTiming ? await getBlockTiming(client) : undefined
+
+  return await Promise.all(
+    [...groups.values()].map((group) => resolvePatchEntities(client, group, blockTiming)),
+  )
+}
+
+/**
+ * Partially updates an entity: fetches its current state, overlays the
+ * provided fields onto it and sends a full update. Omitted fields keep their
+ * current value; attributes are merged (appended, replaced or removed by key,
+ * where a `null` value means removal) instead of replaced wholesale like in
+ * updateEntity.
+ *
+ * **This operation is not atomic.** It reads the entity and then sends an
+ * update transaction as two separate steps. If the entity is modified between
+ * the read and the update landing on chain, those concurrent changes are
+ * silently overwritten and lost.
+ */
+export async function patchEntity(
+  client: ArkivClient,
+  data: PatchEntityParameters,
+  txParams?: TxParams,
+): Promise<PatchEntityReturnType> {
+  logger("patchEntity %o", data)
+  const update = await resolvePatchEntity(client, data)
+  return await updateEntity(client, update, txParams)
+}

--- a/src/actions/wallet/updateEntity.ts
+++ b/src/actions/wallet/updateEntity.ts
@@ -7,28 +7,36 @@ import { getLogger } from "../../utils/logger"
 const logger = getLogger("actions:wallet:update-entity")
 
 /**
- * Parameters for the updateEntity function.
+ * Parameters for the updateEntity function. An update is a **full replace**,
+ * not a patch: the entity's new state is exactly what is passed here, so every
+ * field is required. To change only some fields and keep the rest, use
+ * patchEntity instead.
  * - entityKey: The key of the entity to update.
- * - payload: The payload of the entity.
- * - attributes: The attributes of the entity. Attribute values may be strings
- *   or numbers, but numeric values **must be integers**. To store a non-integer,
- *   scale it to an integer (e.g. `1.5` -> `1500`) to preserve numeric ordering,
- *   or pass it as a string (e.g. `"1.5"`). A non-integer numeric value throws an
- *   {@link InvalidAttributeError}.
- * - contentType: The content type of the entity.
- * - expiresIn: How long until the entity expires, in seconds. Because Arkiv
- *   measures expiration in blocks (1 block = 2 seconds), this **must be a
- *   positive integer and a multiple of the block time (2 seconds)**.
- *   Invalid values throw an {@link InvalidExpirationError}.
+ * - payload: The new payload of the entity, replacing the current one.
+ * - attributes: The new attributes of the entity, replacing **all** current
+ *   ones — any attribute not listed here is removed. Attribute values may be
+ *   strings or numbers, but numeric values **must be integers**. To store a
+ *   non-integer, scale it to an integer (e.g. `1.5` -> `1500`) to preserve
+ *   numeric ordering, or pass it as a string (e.g. `"1.5"`). A non-integer
+ *   numeric value throws an {@link InvalidAttributeError}.
+ * - contentType: The new content type of the entity.
+ * - expiresIn: How long until the entity expires, in seconds, replacing the
+ *   current expiration. Because Arkiv measures expiration in blocks (1 block =
+ *   2 seconds), this **must be a positive integer and a multiple of the block
+ *   time (2 seconds)**. Invalid values throw an {@link InvalidExpirationError}.
  */
 export type UpdateEntityParameters = {
   entityKey: Hex
+  /** New payload, replacing the current one. */
   payload: Uint8Array
-  /** Entity attributes. Numeric values must be integers (scale non-integers, e.g. `1.5` -> `1500`, or use a string). Throws {@link InvalidAttributeError} otherwise. */
+  /** New attributes, replacing **all** current ones — attributes not listed here are
+   * removed. Numeric values must be integers (scale non-integers, e.g. `1.5` -> `1500`,
+   * or use a string). Throws {@link InvalidAttributeError} otherwise. */
   attributes: Attribute[]
+  /** New content type, replacing the current one. */
   contentType: MimeType | string
-  /** Seconds until expiry. Must be a positive integer and a multiple of the 2s block time.
-   * Throws {@link InvalidExpirationError} otherwise. */
+  /** Seconds until expiry, replacing the current expiration. Must be a positive integer
+   * and a multiple of the 2s block time. Throws {@link InvalidExpirationError} otherwise. */
   expiresIn: number
 }
 
@@ -42,6 +50,13 @@ export type UpdateEntityReturnType = {
   txHash: Hash
 }
 
+/**
+ * Replaces an entity's state wholesale with the provided parameters. This is
+ * a **full replace, not a patch**: the payload, content type and expiration
+ * are overwritten, and the attribute set becomes exactly the provided list —
+ * attributes not listed are removed. To change only some fields and keep the
+ * rest, use patchEntity.
+ */
 export async function updateEntity(
   client: ArkivClient,
   data: UpdateEntityParameters,

--- a/src/actions/wallet/updateEntity.ts
+++ b/src/actions/wallet/updateEntity.ts
@@ -55,6 +55,7 @@ export async function updateEntity(
 
   return {
     txHash: receipt.transactionHash as Hash,
-    entityKey: receipt.logs[0].topics[1] as Hex,
+    // fall back to the requested key when the receipt carries no parseable log
+    entityKey: (receipt.logs[0]?.topics[1] as Hex | undefined) ?? data.entityKey,
   }
 }

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -23,6 +23,8 @@ test("creates", () => {
   expect(typeof client.createEntity).toBe("function")
   expect(client.updateEntity).toBeDefined()
   expect(typeof client.updateEntity).toBe("function")
+  expect(client.patchEntity).toBeDefined()
+  expect(typeof client.patchEntity).toBe("function")
   expect(client.deleteEntity).toBeDefined()
   expect(typeof client.deleteEntity).toBe("function")
   expect(client.extendEntity).toBeDefined()

--- a/src/clients/decorators/arkivWallet.ts
+++ b/src/clients/decorators/arkivWallet.ts
@@ -24,6 +24,8 @@ import type {
   MutateEntitiesReturnType,
 } from "../../actions/wallet/mutateEntities"
 import { mutateEntities } from "../../actions/wallet/mutateEntities"
+import type { PatchEntityParameters, PatchEntityReturnType } from "../../actions/wallet/patchEntity"
+import { patchEntity } from "../../actions/wallet/patchEntity"
 import type {
   UpdateEntityParameters,
   UpdateEntityReturnType,
@@ -116,6 +118,68 @@ export type WalletArkivActions<
     ) => Promise<UpdateEntityReturnType>
 
     /**
+     * Partially updates the entity with the given key. Unlike updateEntity,
+     * which replaces the whole entity, patchEntity fetches the entity's
+     * current state, overlays the provided fields onto it and sends a full
+     * update. Omitted fields keep their current value; attributes are merged:
+     * attributes with new keys are appended, attributes with existing keys of
+     * the same value type (string or numeric) have their value replaced, a
+     * value of `null` removes both the string and the numeric attribute with
+     * that key, and the entity's other attributes are kept. If expiresIn is
+     * omitted, the entity's remaining lifetime is preserved as measured at
+     * read time — each such patch can lengthen the lifetime by the blocks
+     * mined until the update lands on chain, so pass expiresIn explicitly
+     * when the exact expiration matters.
+     *
+     * **This operation is not atomic.** It is syntax sugar over getEntity
+     * followed by updateEntity. If the entity is modified by someone else
+     * between the read and the update transaction landing on chain, those
+     * concurrent changes are silently overwritten and lost.
+     *
+     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/patchEntity
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     *
+     * @param data - The entity patch parameters
+     * @param txParams - Optional transaction parameters
+     * @returns The patched entity key with transaction hash
+     *
+     * @throws {NoEntityFoundError} If no entity exists under the given key.
+     * @throws {InvalidExpirationError} If `expiresIn` is provided and is not a
+     * positive integer that is a multiple of the block time (2 seconds).
+     * @throws {InvalidAttributeError} If a numeric attribute value is not an
+     * integer.
+     * @throws {CannotPreserveExpirationError} If `expiresIn` is omitted and
+     * the entity has no expiration block or has already expired.
+     * @throws {UnsafeNumericAttributeError} If an untouched numeric attribute
+     * read back from the entity exceeds Number.MAX_SAFE_INTEGER and so cannot
+     * be written back without risking corruption.
+     *
+     * @example
+     * import { createWalletClient, http } from 'arkiv'
+     * import { braga } from 'arkiv/chains'
+     *
+     * const client = createWalletClient({
+     *   chain: braga,
+     *   transport: http(),
+     * })
+     * // replaces the payload, appends/updates the "newAttr" attribute and
+     * // removes the "oldAttr" attribute, keeping all other attributes, the
+     * // content type and the expiration
+     * const { entityKey, txHash } = await client.patchEntity({
+     *   entityKey: "0x123",
+     *   payload: stringToPayload("new payload"),
+     *   attributes: [
+     *     { key: "newAttr", value: "newVal" },
+     *     { key: "oldAttr", value: null },
+     *   ],
+     * })
+     */
+    patchEntity: (
+      data: PatchEntityParameters,
+      txParams?: TxParams,
+    ) => Promise<PatchEntityReturnType>
+
+    /**
      * Deletes the entity with the given key.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/deleteEntity
@@ -203,14 +267,28 @@ export type WalletArkivActions<
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/mutateEntities
      * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
      *
-     * @param data - The mutation parameters (creates, updates, deletes, extensions)
+     * @param data - The mutation parameters (creates, updates, patches, deletes, extensions)
      * @param txParams - Optional transaction parameters
      * @returns The mutation result with transaction hash
+     *
+     * Patches are resolved into full updates by fetching each entity's current
+     * state first (see patchEntity); their keys are reported in
+     * updatedEntities (once per entity — several patches for the same entity
+     * key are applied in order and folded into a single update). **Patches
+     * are not atomic**: changes made to an entity between that read and the
+     * mutation transaction landing on chain are silently overwritten and lost.
      *
      * @throws {InvalidExpirationError} If any create/update/extension `expiresIn`
      * is not a positive integer that is a multiple of the block time (2 seconds).
      * @throws {InvalidAttributeError} If a numeric attribute value is not an
      * integer.
+     * @throws {NoEntityFoundError} If a patch targets an entity that does not
+     * exist.
+     * @throws {CannotPreserveExpirationError} If a patch omits `expiresIn` and
+     * the entity has no expiration block or has already expired.
+     * @throws {UnsafeNumericAttributeError} If a patched entity has an
+     * untouched numeric attribute above Number.MAX_SAFE_INTEGER that cannot be
+     * written back without risking corruption.
      *
      * @example
      * import { createWalletClient, http } from 'arkiv'
@@ -231,6 +309,10 @@ export type WalletArkivActions<
      *     payload: toBytes(JSON.stringify({ entity: { entityType: "testType", entityId: "testId" } })),
      *     attributes: [{ key: "testKey", value: "testValue" }],
      *     expiresIn: 1000,
+     *   }],
+     *   patches: [{
+     *     entityKey: "0x456",
+     *     attributes: [{ key: "newAttr", value: "newVal" }],
      *   }],
      *   deletes: [{
      *     entityKey: "0x321",
@@ -263,6 +345,8 @@ export function walletArkivActions<
       createEntity(client, data, txParams),
     updateEntity: (data: UpdateEntityParameters, txParams?: TxParams) =>
       updateEntity(client, data, txParams),
+    patchEntity: (data: PatchEntityParameters, txParams?: TxParams) =>
+      patchEntity(client, data, txParams),
     deleteEntity: (data: DeleteEntityParameters, txParams?: TxParams) =>
       deleteEntity(client, data, txParams),
     extendEntity: (data: ExtendEntityParameters, txParams?: TxParams) =>

--- a/src/clients/decorators/arkivWallet.ts
+++ b/src/clients/decorators/arkivWallet.ts
@@ -89,7 +89,12 @@ export type WalletArkivActions<
     ) => Promise<CreateEntityReturnType>
 
     /**
-     * Updates the entity with the given key.
+     * Updates the entity with the given key. This is a **full replace, not a
+     * patch**: the entity's new state is exactly the provided parameters —
+     * the payload, content type and expiration are overwritten, and the
+     * attribute set becomes exactly the provided list, removing any attribute
+     * not listed. To change only some fields and keep the rest, use
+     * patchEntity.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/updateEntity
      * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
@@ -270,6 +275,9 @@ export type WalletArkivActions<
      * @param data - The mutation parameters (creates, updates, patches, deletes, extensions)
      * @param txParams - Optional transaction parameters
      * @returns The mutation result with transaction hash
+     *
+     * Each update is a **full replace**, not a patch: the entity's new state
+     * is exactly the update's parameters (see updateEntity).
      *
      * Patches are resolved into full updates by fetching each entity's current
      * state first (see patchEntity); their keys are reported in

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,6 +23,22 @@ export class InvalidAttributeError extends Error {
   }
 }
 
+export class CannotPreserveExpirationError extends Error {
+  constructor(entityKey: string, reason: string) {
+    super(`Cannot preserve expiration of entity ${entityKey}: ${reason} Pass expiresIn explicitly.`)
+    this.name = "CannotPreserveExpirationError"
+  }
+}
+
+export class UnsafeNumericAttributeError extends Error {
+  constructor(entityKey: string, key: string, value: number) {
+    super(
+      `Cannot patch entity ${entityKey}: its numeric attribute "${key}" was read back as ${String(value)}, which exceeds Number.MAX_SAFE_INTEGER and may have lost precision, so writing it back could corrupt the stored value. Include "${key}" in the patch attributes (with a new value, or null to remove it) to patch this entity.`,
+    )
+    this.name = "UnsafeNumericAttributeError"
+  }
+}
+
 export class NoMoreResultsError extends Error {
   constructor() {
     super("No more results")

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,11 @@ export type {
   MutateEntitiesParameters,
   MutateEntitiesReturnType,
 } from "../actions/wallet/mutateEntities"
+export type {
+  PatchAttribute,
+  PatchEntityParameters,
+  PatchEntityReturnType,
+} from "../actions/wallet/patchEntity"
 export type { UpdateEntityParameters, UpdateEntityReturnType } from "../actions/wallet/updateEntity"
 export type { Attribute } from "./attributes"
 export type { Entity } from "./entity"

--- a/test/src/arkiv.test.ts
+++ b/test/src/arkiv.test.ts
@@ -485,6 +485,92 @@ describe("Arkiv Integration Tests for public client", () => {
   )
 
   test.each(["http", "webSocket"] as const)(
+    "should handle patchEntity using %s",
+    async (transport) => {
+      const writeClient = transport === "http" ? walletClient : walletClientWS
+      const readClient = transport === "http" ? publicClient : publicClientWS
+
+      // create entity
+      const { entityKey } = await writeClient.createEntity({
+        payload: jsonToPayload({ entity: { entityType: "test", entityId: "test" } }),
+        contentType: "application/json",
+        attributes: [
+          { key: "keepKey", value: "keepValue" },
+          { key: "replaceKey", value: "oldValue" },
+        ],
+        expiresIn: ExpirationTime.fromBlocks(1000),
+      })
+      const createdEntity = await readClient.getEntity(entityKey)
+
+      // patch payload and append a new attribute; everything else is kept
+      const { entityKey: patchedEntityKey, txHash: patchedTxHash } = await writeClient.patchEntity({
+        entityKey,
+        payload: jsonToPayload({ entity: { entityType: "patched", entityId: "patched" } }),
+        attributes: [{ key: "newAttr", value: "newVal" }],
+      })
+      console.log("result from patchEntity", { patchedEntityKey, patchedTxHash })
+      expect(patchedEntityKey).toEqual(entityKey)
+
+      const patchedEntity = await readClient.getEntity(entityKey)
+      expect(patchedEntity.payload).toEqual(
+        jsonToPayload({ entity: { entityType: "patched", entityId: "patched" } }),
+      )
+      expect(patchedEntity.contentType).toEqual("application/json")
+      expect(patchedEntity.attributes).toContainEqual({ key: "keepKey", value: "keepValue" })
+      expect(patchedEntity.attributes).toContainEqual({ key: "replaceKey", value: "oldValue" })
+      expect(patchedEntity.attributes).toContainEqual({ key: "newAttr", value: "newVal" })
+      expect(patchedEntity.attributes.length).toEqual(3)
+      // remaining lifetime is approximately preserved (a few blocks pass
+      // between the read and the update landing)
+      expect(patchedEntity.expiresAtBlock).toBeDefined()
+      const expirationDriftBlocks =
+        (patchedEntity.expiresAtBlock as bigint) - (createdEntity.expiresAtBlock as bigint)
+      expect(expirationDriftBlocks).toBeGreaterThanOrEqual(0n)
+      expect(expirationDriftBlocks).toBeLessThanOrEqual(30n)
+
+      // patch an existing attribute's value; payload is kept
+      await writeClient.patchEntity({
+        entityKey,
+        attributes: [{ key: "replaceKey", value: "newValue" }],
+      })
+      const repatchedEntity = await readClient.getEntity(entityKey)
+      expect(repatchedEntity.payload).toEqual(
+        jsonToPayload({ entity: { entityType: "patched", entityId: "patched" } }),
+      )
+      expect(repatchedEntity.attributes).toContainEqual({ key: "replaceKey", value: "newValue" })
+      expect(repatchedEntity.attributes.length).toEqual(3)
+
+      // patches are also supported in mutateEntities and reported as updates
+      const mutateResult = await writeClient.mutateEntities({
+        patches: [
+          {
+            entityKey,
+            attributes: [{ key: "mutatedAttr", value: "mutatedVal" }],
+          },
+        ],
+      })
+      console.log("result from mutateEntities with patches", mutateResult)
+      expect(mutateResult.updatedEntities).toEqual([entityKey])
+      const mutatedEntity = await readClient.getEntity(entityKey)
+      expect(mutatedEntity.attributes).toContainEqual({ key: "mutatedAttr", value: "mutatedVal" })
+      expect(mutatedEntity.attributes.length).toEqual(4)
+
+      // a null value removes the attribute
+      await writeClient.patchEntity({
+        entityKey,
+        attributes: [{ key: "newAttr", value: null }],
+      })
+      const prunedEntity = await readClient.getEntity(entityKey)
+      expect(prunedEntity.attributes).not.toContainEqual({ key: "newAttr", value: "newVal" })
+      expect(prunedEntity.attributes.length).toEqual(3)
+
+      // cleanup
+      await writeClient.deleteEntity({ entityKey })
+    },
+    { timeout: basicCRUDTestTimeout },
+  )
+
+  test.each(["http", "webSocket"] as const)(
     "should handle mutateEntities using %s",
     async (transport) => {
       const newOwner = "0x6186b0dba9652262942d5a465d49686eb560834c" as Hex


### PR DESCRIPTION
closes https://github.com/Arkiv-Network/arkiv-sdk-js/issues/79

Things to note:
- ARKIV allows us to set 2 attributes with the same name but different value types, which is why I introduced `typedKey` to compare what attribute should be added, removed or changed. 
- If the user provides the same entity in `patchedEntites` multiple times I collapse all changes into one final set of operations.
- `patchEntity` only fetches the current block number if the expiration doesn't change
- You can unset an attrbute by setting its value to `null` 
- We cast each entity to a javascript number which can represent an integer up to 2^53-1. So in theory if an entity has a numeric attribute larger then that we could lose precision during a patch. I added a safeguard around this with `UnsafeNumericAttributeError` but IMO at some point we should migrate numeric attributes in the SDK from `number` to `bigint` (like viem does it)