### PR TITLE
Reth types CR fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This release tracks the arkiv-reth engine and rewrites most of the SDK surface. 
 - **Breaking:** entity metadata fields were renamed: `createdAtBlock` is `createdAt`, `lastModifiedAtBlock` is `updatedAt` and `expiresAtBlock` is `expiresAt`. `transactionIndexInBlock` and `operationIndexInTransaction` are gone
 - **Breaking:** `getEntity()` returns a `FullEntity` with every field populated
 - **Breaking:** `QueryOptions` now takes `select` (a selection) and `limit`, replacing `includeData` and `resultsPerPage`. Page size is capped at 200
-- **Breaking:** `mutateEntities()` takes `patches` where it took `updates`, and gained `ownershipChanges`.
+- **Breaking:** `mutateEntities()` is now `executeBatch()`. It takes `patches` where it took `updates`, and gained `ownershipChanges`. `MutateEntitiesParameters` and `MutateEntitiesReturnType` are `ExecuteBatchParameters` and `ExecuteBatchReturnType`
 - **Breaking:** `QueryResult.next()` returns the next page as a new `QueryResult` instead of mutating the current one
 - `owner` and `creator` are returned as checksummed addresses
 - Error types match the new operations: `InvalidExpiryError`, `InvalidValueError`, `InvalidAttributeNameError`, `ConflictingMutationError`, `EmptyPatchError`, `TooManyAttributesError`, `InvalidCreationFlagsError`, `InvalidSaltError`, `QueryError`

--- a/src/actions/public/getEntity.ts
+++ b/src/actions/public/getEntity.ts
@@ -5,6 +5,7 @@ import { NoEntityFoundError } from "../../errors"
 import { runQuery } from "../../query/engine"
 import { eq } from "../../query/expression"
 import { type FullEntity, toRpcSelect } from "../../query/selection"
+import type { Entity } from "../../types/entity"
 
 /**
  * Reads one entity by key, with every field selected.

--- a/src/actions/public/predictEntityKeys.test.ts
+++ b/src/actions/public/predictEntityKeys.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "bun:test"
 import { encodeFunctionResult, type Hex } from "viem"
 import type { ArkivClient } from "../../clients/baseClient"
 import { ARKIV_ADDRESS } from "../../consts"
-import { predictEntityKey } from "../../entity/key"
+import { NO_SALT, predictEntityKey } from "../../entity/key"
 import { ENTITY_NONCE_ABI } from "../../entity/operations"
 import { getEntityNonce } from "./getEntityNonce"
 import { predictEntityKeys } from "./predictEntityKeys"
@@ -103,6 +103,22 @@ describe("predictEntityKeys", () => {
         }),
       ),
     )
+  })
+
+  it("takes NO_SALT in a slot, and pairs the key with the zero it resolves to", async () => {
+    const { client } = makeClient(4n)
+    const [first, second] = await predictEntityKeys(client, {
+      owner: OWNER,
+      salts: [NO_SALT, 5n],
+    })
+    expect(first).toEqual({
+      salt: 0n,
+      key: predictEntityKey({ owner: OWNER, nonce: 4n, salt: 0n, chainId: CHAIN_ID }),
+    })
+    expect(second).toEqual({
+      salt: 5n,
+      key: predictEntityKey({ owner: OWNER, nonce: 5n, salt: 5n, chainId: CHAIN_ID }),
+    })
   })
 
   it("prefers the salts it was given over the count", async () => {

--- a/src/actions/public/predictEntityKeys.ts
+++ b/src/actions/public/predictEntityKeys.ts
@@ -1,7 +1,13 @@
 import type { Address, Hex } from "viem"
 import { getChainId } from "viem/actions"
 import type { ArkivClient } from "../../clients/baseClient"
-import { predictEntityKey, randomSalt, validateSalt } from "../../entity/key"
+import {
+  NO_SALT,
+  predictEntityKey,
+  randomSalt,
+  resolveSalt,
+  type SaltInput,
+} from "../../entity/key"
 import { getEntityNonce } from "./getEntityNonce"
 
 /**
@@ -13,14 +19,18 @@ import { getEntityNonce } from "./getEntityNonce"
 export type PredictedEntityKey = {
   /** The key the create will be given. */
   key: Hex
-  /** The salt the create must carry for its key to come out as {@link PredictedEntityKey.key}. */
+  /**
+   * The salt the create must carry for its key to come out as {@link PredictedEntityKey.key}.
+   * Always a plain `uint128` — a requested {@link NO_SALT} comes back as the `0n` it resolves to,
+   * which a create accepts just the same.
+   */
   salt: bigint
 }
 
 /** Parameters for `client.predictEntityKeys`. */
 export type PredictEntityKeysParameters<
   TCount extends number = number,
-  TSalts extends readonly bigint[] | undefined = readonly bigint[] | undefined,
+  TSalts extends readonly SaltInput[] | undefined = readonly SaltInput[] | undefined,
 > = {
   /** The account that will sign the creates. Its nonce is what the keys are derived from. */
   owner: Address
@@ -34,7 +44,8 @@ export type PredictEntityKeysParameters<
   count?: TCount | undefined
   /**
    * The salt each create will carry, in batch order. Defaults to `count` fresh random salts —
-   * either way each key comes back paired with the salt that mints it.
+   * either way each key comes back paired with the salt that mints it. Pass {@link NO_SALT} in a
+   * slot whose create opts out of salting.
    */
   salts?: TSalts
 }
@@ -46,13 +57,13 @@ export type PredictEntityKeysParameters<
  * tuple, gives a fixed-length tuple; a count computed at runtime gives a plain array.
  *
  * `TSalts` is wrapped in a tuple to stop the conditional distributing over it. Left naked, the
- * `readonly bigint[] | undefined` default would take both branches and union a tuple with an array,
- * which widens the length straight back to `number`.
+ * `readonly SaltInput[] | undefined` default would take both branches and union a tuple with an
+ * array, which widens the length straight back to `number`.
  */
 export type PredictEntityKeysReturnType<
   TCount extends number = number,
-  TSalts extends readonly bigint[] | undefined = readonly bigint[] | undefined,
-> = [TSalts] extends [readonly bigint[]]
+  TSalts extends readonly SaltInput[] | undefined = readonly SaltInput[] | undefined,
+> = [TSalts] extends [readonly SaltInput[]]
   ? { -readonly [Index in keyof TSalts]: PredictedEntityKey }
   : Repeat<PredictedEntityKey, TCount>
 
@@ -104,7 +115,7 @@ type Repeat<T, TLength extends number, TAcc extends T[] = []> = number extends T
  */
 export async function predictEntityKeys<
   const TCount extends number = number,
-  const TSalts extends readonly bigint[] | undefined = undefined,
+  const TSalts extends readonly SaltInput[] | undefined = undefined,
 >(
   client: ArkivClient,
   { owner, count, salts }: PredictEntityKeysParameters<TCount, TSalts>,
@@ -121,12 +132,15 @@ export async function predictEntityKeys<
 }
 
 /** The salts to derive from: the ones given, or `count` fresh random ones. */
-function resolveSalts(count: number | undefined, salts: readonly bigint[] | undefined): bigint[] {
+function resolveSalts(
+  count: number | undefined,
+  salts: readonly SaltInput[] | undefined,
+): bigint[] {
   if (salts !== undefined) {
     if (salts.length === 0) {
       throw new Error("predictEntityKeys: `salts` is empty — there is nothing to predict")
     }
-    return salts.map(validateSalt)
+    return salts.map(resolveSalt)
   }
   if (count === undefined) {
     throw new Error("predictEntityKeys: pass either `count` or `salts`")

--- a/src/actions/public/predictEntityKeys.ts
+++ b/src/actions/public/predictEntityKeys.ts
@@ -90,7 +90,7 @@ type Repeat<T, TLength extends number, TAcc extends T[] = []> = number extends T
  *
  * The prediction is valid only while nothing else from this owner is in flight. Every create that
  * lands first takes the nonce with it and moves these keys. For a key you can rely on
- * unconditionally, read it back from the create instead — `createEntity` and `mutateEntities`
+ * unconditionally, read it back from the create instead — `createEntity` and `executeBatch`
  * report the keys the engine actually minted.
  *
  * @param parameters - Owner, and either a count or the salts. {@link PredictEntityKeysParameters}
@@ -100,7 +100,7 @@ type Repeat<T, TLength extends number, TAcc extends T[] = []> = number extends T
  * import { key } from "@arkiv-network/sdk/attr"
  *
  * const [parent, child] = await client.predictEntityKeys({ owner: account.address, count: 2 })
- * await client.mutateEntities({
+ * await client.executeBatch({
  *   creates: [
  *     { payload, contentType, expires, salt: parent.salt },
  *     {

--- a/src/actions/public/predictEntityKeys.ts
+++ b/src/actions/public/predictEntityKeys.ts
@@ -17,7 +17,7 @@ export type PredictedEntityKey = {
   salt: bigint
 }
 
-/** Parameters for {@link predictEntityKeys}. */
+/** Parameters for `client.predictEntityKeys`. */
 export type PredictEntityKeysParameters<
   TCount extends number = number,
   TSalts extends readonly bigint[] | undefined = readonly bigint[] | undefined,
@@ -89,7 +89,7 @@ type Repeat<T, TLength extends number, TAcc extends T[] = []> = number extends T
  * import { key } from "@arkiv-network/sdk/attr"
  *
  * const [parent, child] = await client.predictEntityKeys({ owner: account.address, count: 2 })
- * await wallet.mutateEntities({
+ * await client.mutateEntities({
  *   creates: [
  *     { payload, contentType, expires, salt: parent.salt },
  *     {

--- a/src/actions/wallet/createEntity.ts
+++ b/src/actions/wallet/createEntity.ts
@@ -5,6 +5,7 @@ import type { CreationFlags, Expiry } from "../../entity"
 import { EntityMutationError } from "../../errors"
 import type { MimeType, TxParams } from "../../types"
 import { sendArkivTransaction } from "../../utils/arkivTransactions"
+import type { ExpirationTime } from "../../utils/expirationTime"
 import { getLogger } from "../../utils/logger"
 
 const logger = getLogger("actions:wallet:create-entity")
@@ -66,8 +67,8 @@ export type CreateEntityParameters = {
   contentType: MimeType | (string & {})
   /**
    * The entity's queryable attributes, keyed by name. Values are the tagged constructors from
-   * `@arkiv-network/sdk/attr` — `i32`, `u256`, `dec`, `str`, `addr`, `key`, `bytes32`, `bool` — or
-   * a bare `boolean`, `number`, `bigint` or `string` where the type is unambiguous.
+   * `@arkiv-network/sdk/attr` — `i32`, `u64`, `u256`, `dec`, `str`, `addr`, `key`, `bytes32`,
+   * `bool` — or a bare `boolean`, `number`, `bigint` or `string` where the type is unambiguous.
    *
    * @throws {InvalidAttributeNameError} If a name violates the attribute-name grammar.
    * @throws {InvalidValueError} If a value does not fit the type it names or defaults to.

--- a/src/actions/wallet/createEntity.ts
+++ b/src/actions/wallet/createEntity.ts
@@ -1,7 +1,7 @@
 import type { Hash, Hex } from "viem"
 import type { AttributeInputs } from "../../attr"
 import type { ArkivClient } from "../../clients/baseClient"
-import type { CreationFlags, Expiry } from "../../entity"
+import type { CreationFlags, Expiry, NO_SALT, SaltInput } from "../../entity"
 import { EntityMutationError } from "../../errors"
 import type { MimeType, TxParams } from "../../types"
 import { sendArkivTransaction } from "../../utils/arkivTransactions"
@@ -83,10 +83,10 @@ export type CreateEntityParameters = {
    * The salt mixed into the entity key. Defaults to 128 random bits, which makes the key
    * unpredictable to everyone but the creator.
    *
-   * Pass `0n` for a key derived from the owner and nonce alone — predictable by anyone, which is
-   * what you want only when a third party must be able to compute the key in advance.
+   * Pass {@link NO_SALT} for a key derived from the owner and nonce alone — predictable by anyone,
+   * which is what you want only when a third party must be able to compute the key in advance.
    */
-  salt?: bigint | undefined
+  salt?: SaltInput | undefined
 }
 
 /**

--- a/src/actions/wallet/executeBatch.test.ts
+++ b/src/actions/wallet/executeBatch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "bun:test"
 import type { ArkivClient } from "../../clients/baseClient"
-import { mutateEntities } from "./mutateEntities"
+import { executeBatch } from "./executeBatch"
 
 const ENTITY_KEY = `0x${"ab".repeat(32)}` as const
 const NEW_OWNER = "0x2222222222222222222222222222222222222222"
@@ -29,7 +29,7 @@ describe("the empty-batch guard", () => {
     // An ownership-only batch is a batch: it used to be rejected because the guard listed
     // creates/updates/deletes/extensions and forgot ownershipChanges.
     const { client, writeContract } = makeClient()
-    const result = await mutateEntities(client, {
+    const result = await executeBatch(client, {
       ownershipChanges: [{ entityKey: ENTITY_KEY, newOwner: NEW_OWNER }],
     })
     expect(writeContract).toHaveBeenCalledTimes(1)
@@ -38,9 +38,9 @@ describe("the empty-batch guard", () => {
 
   it("rejects a batch with nothing in it", async () => {
     const { client, writeContract } = makeClient()
-    await expect(mutateEntities(client, {})).rejects.toThrow(/No operations/)
+    await expect(executeBatch(client, {})).rejects.toThrow(/No operations/)
     // Present but empty is just as empty — the engine would revert with EmptyBatch().
-    await expect(mutateEntities(client, { deletes: [], ownershipChanges: [] })).rejects.toThrow(
+    await expect(executeBatch(client, { deletes: [], ownershipChanges: [] })).rejects.toThrow(
       /No operations/,
     )
     expect(writeContract).not.toHaveBeenCalled()
@@ -52,10 +52,10 @@ describe("the empty-batch guard", () => {
     // keys would score this batch as non-empty and then drop it on the way to the wire, sending
     // execute([]) — so the guard counts the five kinds that actually reach the transaction.
     const stale = { updates: [{ entityKey: ENTITY_KEY, set: { level: 1 } }] } as never
-    await expect(mutateEntities(client, stale)).rejects.toThrow(/No operations/)
+    await expect(executeBatch(client, stale)).rejects.toThrow(/No operations/)
     // A typo is the same mistake with a different name.
     await expect(
-      mutateEntities(client, { delete: [{ entityKey: ENTITY_KEY }] } as never),
+      executeBatch(client, { delete: [{ entityKey: ENTITY_KEY }] } as never),
     ).rejects.toThrow(/No operations/)
     expect(writeContract).not.toHaveBeenCalled()
   })
@@ -65,7 +65,7 @@ describe("the empty-batch guard", () => {
     // The dangerous shape: the creates apply and the transaction succeeds, so nothing surfaces the
     // fact that the `updates` never happened. The guard cannot catch this one — only the caller's
     // types can — but the result must at least not claim they did.
-    const result = await mutateEntities(client, {
+    const result = await executeBatch(client, {
       deletes: [{ entityKey: ENTITY_KEY }],
       updates: [{ entityKey: ENTITY_KEY, set: { level: 1 } }],
     } as never)

--- a/src/actions/wallet/executeBatch.ts
+++ b/src/actions/wallet/executeBatch.ts
@@ -9,15 +9,15 @@ import type { DeleteEntityParameters } from "./deleteEntity"
 import type { ExtendEntityParameters } from "./extendEntity"
 import type { PatchEntityParameters } from "./patchEntity"
 
-const logger = getLogger("actions:wallet:mutate-entities")
+const logger = getLogger("actions:wallet:execute-batch")
 
 /**
- * Parameters for the mutateEntities function.
+ * Parameters for the executeBatch function.
  *
  * At least one operation is required; a batch with nothing in it throws rather than spending gas on
  * an empty transaction.
  */
-export type MutateEntitiesParameters = {
+export type ExecuteBatchParameters = {
   /** The entities to create. */
   creates?: CreateEntityParameters[]
   /** The patches to apply. */
@@ -30,8 +30,8 @@ export type MutateEntitiesParameters = {
   ownershipChanges?: ChangeOwnershipParameters[]
 }
 
-/** Return type for the mutateEntities function. */
-export type MutateEntitiesReturnType = {
+/** Return type for the executeBatch function. */
+export type ExecuteBatchReturnType = {
   /** The transaction hash. */
   txHash: Hash
   /** The keys of the created entities, in batch order. */
@@ -46,14 +46,14 @@ export type MutateEntitiesReturnType = {
   ownershipChanges: Hex[]
 }
 
-export async function mutateEntities(
+export async function executeBatch(
   client: ArkivClient,
-  data: MutateEntitiesParameters,
+  data: ExecuteBatchParameters,
   txParams?: TxParams,
-): Promise<MutateEntitiesReturnType> {
+): Promise<ExecuteBatchReturnType> {
   const { receipt, createdEntityKeys } = await sendArkivTransaction(client, data, txParams)
 
-  logger("Receipt from mutateEntities %o", receipt)
+  logger("Receipt from executeBatch %o", receipt)
 
   return {
     txHash: receipt.transactionHash as Hash,

--- a/src/actions/wallet/extendEntity.ts
+++ b/src/actions/wallet/extendEntity.ts
@@ -4,6 +4,7 @@ import type { Expiry } from "../../entity"
 import { EntityMutationError } from "../../errors"
 import type { TxParams } from "../../types"
 import { sendArkivTransaction } from "../../utils/arkivTransactions"
+import type { ExpirationTime } from "../../utils/expirationTime"
 import { getLogger } from "../../utils/logger"
 
 const logger = getLogger("actions:wallet:extend-entity")

--- a/src/actions/wallet/patchEntity.ts
+++ b/src/actions/wallet/patchEntity.ts
@@ -38,9 +38,9 @@ export type PatchEntityParameters = {
    * Attributes to write, keyed by name. An existing attribute is overwritten — including with a
    * different type — and a name the entity does not carry yet is added.
    *
-   * Values are the tagged constructors from `@arkiv-network/sdk/attr` — `i32`, `u256`, `dec`, `str`,
-   * `addr`, `key`, `bytes32`, `bool` — or a bare `boolean`, `number`, `bigint` or `string` where the
-   * type is unambiguous.
+   * Values are the tagged constructors from `@arkiv-network/sdk/attr` — `i32`, `u64`, `u256`,
+   * `dec`, `str`, `addr`, `key`, `bytes32`, `bool` — or a bare `boolean`, `number`, `bigint` or
+   * `string` where the type is unambiguous.
    *
    * @throws {InvalidAttributeNameError} If a name violates the attribute-name grammar.
    * @throws {InvalidValueError} If a value does not fit the type it names or defaults to.

--- a/src/attr/attributes.ts
+++ b/src/attr/attributes.ts
@@ -10,6 +10,10 @@ import { str, toValue, type ValueInput } from "./values"
  */
 export const MAX_ATTRIBUTES = 32
 
+/**
+ * The largest payload an entity may carry, in bytes. The payload travels as the `$payload` system
+ * cell, so this is a bound on that one attribute rather than on the operation as a whole.
+ */
 export const MAX_PAYLOAD_BYTES = 128 * 1024
 
 /** The system attribute holding an entity's opaque payload. */
@@ -20,7 +24,7 @@ const CONTENT_TYPE_CELL = "$contentType"
 /**
  * The attributes written on an entity, as a plain object keyed by attribute name.
  *
- * Values may be tagged ({@link ValueInput}) or bare where the type is unambiguous — see
+ * Values may be tagged ({@link ArkivValue}) or bare where the type is unambiguous — see
  * {@link toValue} for the bare-form defaults.
  *
  * @example
@@ -141,8 +145,10 @@ export type MutationInputs = SystemCells & {
  *
  * @throws {ConflictingMutationError} If a name appears in both `set` and `unset`.
  * @throws {InvalidAttributeNameError} If a name violates the attribute-name grammar.
+ * @throws {MissingValueError} If a value is `undefined` or `null`.
  * @throws {InvalidValueError} If a value does not fit its type.
- * @throws {TooManyAttributesError} If `set` names more than {@link MAX_ATTRIBUTES} attributes.
+ * @throws {TooManyAttributesError} If the mutations exceed {@link MAX_ATTRIBUTES}.
+ * @throws {TypeError} If `unset` is not an array.
  */
 export function encodeMutations({
   set,

--- a/src/attr/errors.ts
+++ b/src/attr/errors.ts
@@ -32,8 +32,8 @@ export class UntypedValueError extends Error {
   constructor(input: unknown) {
     super(
       `Cannot infer an Arkiv type for ${describe(input)}. ` +
-        "Attribute values must be a tagged value (i32, u256, dec, str, addr, key, bytes32, bool) " +
-        "or a bare boolean, number, bigint or string.",
+        "Attribute values must be a tagged value (i32, u64, u256, dec, str, addr, key, bytes32, " +
+        "bool) or a bare boolean, number, bigint or string.",
     )
     this.name = "UntypedValueError"
     this.input = input

--- a/src/attr/types.ts
+++ b/src/attr/types.ts
@@ -1,4 +1,5 @@
 import type { Address, Hex } from "viem"
+import type { decUnits } from "./values"
 
 /**
  * The protocol's attribute type vocabulary, mapping each short **tag** (the name used by the
@@ -54,8 +55,7 @@ export function isUserSettable(tag: TypeTag): tag is UserTypeTag {
 /**
  * Marks a value as having passed its constructor's validation. The symbol is module-private, so a
  * hand-written object literal is not assignable to {@link ArkivValue} — every value crossing the
- * wire has been range-, length- and format-checked by {@link i32}, {@link u256}, {@link dec}, and
- * friends.
+ * wire has been range-, length- and format-checked by `i32`, `u256`, `dec`, and friends.
  */
 declare const validated: unique symbol
 
@@ -89,7 +89,7 @@ export type U256Value = Value<"u256", bigint>
 export type DecValue = Value<"dec", string>
 /** 32 opaque bytes, as lowercase `0x` hex. */
 export type Bytes32Value = Value<"bytes32", Hex>
-/** A UTF-8 string of at most 128 bytes. */
+/** A UTF-8 string of at most 128 bytes, free of C0 control characters and DEL. */
 export type StrValue = Value<"str", string>
 /** A 20-byte Ethereum address, as EIP-55 checksummed hex. */
 export type AddrValue = Value<"addr", Address>

--- a/src/attr/values.ts
+++ b/src/attr/values.ts
@@ -271,7 +271,11 @@ export function decFromUnits(units: bigint): DecValue {
  *
  * The limit is on **bytes**, not characters: a string of 128 emoji does not fit.
  *
- * @throws {InvalidValueError} If the string exceeds 128 UTF-8 bytes.
+ * C0 control characters and DEL are rejected: the query language writes a `str` as `str('...')`,
+ * whose only escape is a doubled quote, so a control character could be stored but never queried.
+ *
+ * @throws {InvalidValueError} If the value is not a string, holds a control character, or exceeds
+ * 128 UTF-8 bytes.
  *
  * @example
  * str("Bob")

--- a/src/chains/localhost.ts
+++ b/src/chains/localhost.ts
@@ -1,5 +1,8 @@
 import { defineChain } from "viem"
 
+/**
+ * A node running on the local machine
+ */
 export const localhost = defineChain({
   id: 1337,
   name: "Localhost",

--- a/src/clients/createPublicClient.test.ts
+++ b/src/clients/createPublicClient.test.ts
@@ -35,5 +35,5 @@ test("creates", () => {
   expect(client.deleteEntity).not.toBeDefined()
   expect(client.extendEntity).not.toBeDefined()
   expect(client.changeOwnership).not.toBeDefined()
-  expect(client.mutateEntities).not.toBeDefined()
+  expect(client.executeBatch).not.toBeDefined()
 })

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -27,10 +27,12 @@ export type PublicArkivClient<
  *
  * - Docs: https://docs.arkiv.network/ts-sdk/clients/public
  *
- * A Public Client is an interface to "public" [Ethereum JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/), [Arkiv JSON-RPC API](https://docs.arkiv.network/json-rpc/), and [Cheesecake JSON-RPC API](https://rpc.cheesecake.db-chain.devnet.gobas.me) methods such as retrieving block numbers, transactions, reading from smart contracts, etc through [Public Actions](/docs/actions/public/introduction).
+ * A Public Client is an interface to the "public" [Ethereum JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+ * and the [Arkiv JSON-RPC API](https://docs.arkiv.network/json-rpc/) — retrieving block numbers and
+ * transactions, reading from contracts, and querying entities — through {@link PublicArkivActions}.
  *
  * @param parameters - Configuration object for the public client (chain, transport, etc.)
- * @returns A Arkiv Public Client. {@link PublicArkivClient}
+ * @returns An Arkiv Public Client. {@link PublicArkivClient}
  *
  * @example
  * import { createPublicClient } from "@arkiv-network/sdk"

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -23,13 +23,11 @@ export type PublicArkivClient<
 >
 
 /**
- * Creates a Public Client with a given [Transport](https://viem.sh/docs/clients/intro) configured for a [Chain](https://viem.sh/docs/clients/chains).
- *
- * - Docs: https://docs.arkiv.network/ts-sdk/clients/public
+ * Creates a Public Client with a given [Transport](https://viem.sh/docs/clients/intro) configured for a [Chain](https://viem.sh/docs/chains/introduction).
  *
  * A Public Client is an interface to the "public" [Ethereum JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/)
- * and the [Arkiv JSON-RPC API](https://docs.arkiv.network/json-rpc/) — retrieving block numbers and
- * transactions, reading from contracts, and querying entities — through {@link PublicArkivActions}.
+ * and the Arkiv JSON-RPC API — retrieving block numbers and transactions, reading from
+ * contracts, and querying entities — through {@link PublicArkivActions}.
  *
  * @param parameters - Configuration object for the public client (chain, transport, etc.)
  * @returns An Arkiv Public Client. {@link PublicArkivClient}

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -29,6 +29,6 @@ test("creates", () => {
   expect(typeof client.extendEntity).toBe("function")
   expect(client.changeOwnership).toBeDefined()
   expect(typeof client.changeOwnership).toBe("function")
-  expect(client.mutateEntities).toBeDefined()
-  expect(typeof client.mutateEntities).toBe("function")
+  expect(client.executeBatch).toBeDefined()
+  expect(typeof client.executeBatch).toBe("function")
 })

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -33,7 +33,7 @@ export type WalletArkivClient<
  * `changeOwnership` and `mutateEntities` — on top of the read actions a Public Client has.
  *
  * @param parameters - Configuration object for the wallet client (chain, transport, account, etc.)
- * @returns A Arkiv Wallet Client. {@link WalletArkivClient}
+ * @returns An Arkiv Wallet Client. {@link WalletArkivClient}
  *
  * @example
  * import { createWalletClient } from "@arkiv-network/sdk"

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -24,9 +24,7 @@ export type WalletArkivClient<
 
 /**
  * Creates a Wallet Client with a given [Transport](https://viem.sh/docs/clients/intro) configured
- * for a [Chain](https://viem.sh/docs/clients/chains) and an account.
- *
- * - Docs: https://docs.arkiv.network/ts-sdk/clients/wallet
+ * for a [Chain](https://viem.sh/docs/chains/introduction) and an account.
  *
  * A Wallet Client signs and sends transactions, so it carries an `account` and exposes everything
  * that mutates state — `createEntity`, `patchEntity`, `deleteEntity`, `extendEntity`,

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -30,7 +30,7 @@ export type WalletArkivClient<
  *
  * A Wallet Client signs and sends transactions, so it carries an `account` and exposes everything
  * that mutates state — `createEntity`, `patchEntity`, `deleteEntity`, `extendEntity`,
- * `changeOwnership` and `mutateEntities` — on top of the read actions a Public Client has.
+ * `changeOwnership` and `executeBatch` — on top of the read actions a Public Client has.
  *
  * @param parameters - Configuration object for the wallet client (chain, transport, account, etc.)
  * @returns An Arkiv Wallet Client. {@link WalletArkivClient}

--- a/src/clients/decorators/arkivPublic.ts
+++ b/src/clients/decorators/arkivPublic.ts
@@ -39,7 +39,7 @@ export type PublicArkivActions<
   /**
    * Returns the entity with the given key.
    *
-   * - Docs: https://docs.arkiv.network/ts-sdk/actions/public/getEntity
+   * - JSON-RPC Methods: `arkiv_query`
    *
    * @param key - The entity key (hex string)
    * @returns The entity with the given key, with every field populated. {@link FullEntity}
@@ -74,7 +74,7 @@ export type PublicArkivActions<
    * read entities. You declare up front which parts of an entity you want returned, so results
    * always contain exactly the data you asked for.
    *
-   * - Docs: https://docs.arkiv.network/ts-sdk/actions/public/query
+   * - JSON-RPC Methods: `arkiv_query`
    *
    * @param selection - What to include in the results. Omit it (or pass `"*"`) to select everything,
    *   or pass an object to select specific parts (at least one field is required). Every part is

--- a/src/clients/decorators/arkivPublic.ts
+++ b/src/clients/decorators/arkivPublic.ts
@@ -229,7 +229,7 @@ export type PublicArkivActions<
    * import { key } from "@arkiv-network/sdk/attr"
    *
    * const [parent, child] = await client.predictEntityKeys({ owner: account.address, count: 2 })
-   * await wallet.mutateEntities({
+   * await wallet.executeBatch({
    *   creates: [
    *     { payload, contentType, expires, salt: parent.salt },
    *     {

--- a/src/clients/decorators/arkivPublic.ts
+++ b/src/clients/decorators/arkivPublic.ts
@@ -13,6 +13,7 @@ import {
   type WatchEntityEventsParameters,
   watchEntityEvents,
 } from "../../actions/public/watchEntityEvents"
+import type { SaltInput } from "../../entity/key"
 import type { Expression } from "../../query/expression"
 import { SelectQueryBuilder } from "../../query/queryBuilder"
 import type { EntitySelection, FullEntity, ProjectedEntity, SelectArg } from "../../query/selection"
@@ -243,7 +244,7 @@ export type PublicArkivActions<
    */
   predictEntityKeys: <
     const TCount extends number = number,
-    const TSalts extends readonly bigint[] | undefined = undefined,
+    const TSalts extends readonly SaltInput[] | undefined = undefined,
   >(
     parameters: PredictEntityKeysParameters<TCount, TSalts>,
   ) => Promise<PredictEntityKeysReturnType<TCount, TSalts>>
@@ -314,7 +315,7 @@ export function publicArkivActions<
     getEntityNonce: (owner: Address) => getEntityNonce(client, owner),
     predictEntityKeys: <
       const TCount extends number = number,
-      const TSalts extends readonly bigint[] | undefined = undefined,
+      const TSalts extends readonly SaltInput[] | undefined = undefined,
     >(
       parameters: PredictEntityKeysParameters<TCount, TSalts>,
     ) => predictEntityKeys(client, parameters),

--- a/src/clients/decorators/arkivPublic.ts
+++ b/src/clients/decorators/arkivPublic.ts
@@ -1,5 +1,5 @@
 import type { Account, Address, Chain, Client, Hex, PublicActions, Transport } from "viem"
-import { getBlockTiming } from "../../actions/public/getBlockTiming"
+import { type GetBlockTimingReturnType, getBlockTiming } from "../../actions/public/getBlockTiming"
 import { getEntity } from "../../actions/public/getEntity"
 import { getEntityCount } from "../../actions/public/getEntityCount"
 import { getEntityNonce } from "../../actions/public/getEntityNonce"
@@ -42,6 +42,10 @@ export type PublicArkivActions<
    *
    * @param key - The entity key (hex string)
    * @returns The entity with the given key, with every field populated. {@link FullEntity}
+   *
+   * @throws {InvalidValueError} If the key is not 32 bytes.
+   * @throws {NoEntityFoundError} If no live entity has that key — it never existed, or it was
+   * deleted or has expired.
    *
    * @example
    * import { createPublicClient } from "@arkiv-network/sdk"
@@ -130,7 +134,7 @@ export type PublicArkivActions<
   /**
    * Runs one query and returns one page, with no builder in between.
    *
-   * Use {@link select} for anything typed — this returns full {@link Entity} objects whatever the
+   * Use {@link PublicArkivActions.select} for anything typed — this returns full {@link Entity} objects whatever the
    * selection, and takes a raw string as an escape hatch for a query built elsewhere. A raw string
    * goes to the node exactly as written, with none of the name, type or operator checks the
    * expression combinators apply.
@@ -264,11 +268,7 @@ export type PublicArkivActions<
    * //   blockDuration: 2, // in seconds
    * // }
    */
-  getBlockTiming: () => Promise<{
-    currentBlock: bigint
-    currentBlockTime: number
-    blockDuration: number
-  }>
+  getBlockTiming: () => Promise<GetBlockTimingReturnType>
 
   /**
    * Watches entity events, calling the handlers you pass as they arrive.

--- a/src/clients/decorators/arkivWallet.ts
+++ b/src/clients/decorators/arkivWallet.ts
@@ -15,15 +15,15 @@ import type {
 } from "../../actions/wallet/deleteEntity"
 import { deleteEntity } from "../../actions/wallet/deleteEntity"
 import type {
+  ExecuteBatchParameters,
+  ExecuteBatchReturnType,
+} from "../../actions/wallet/executeBatch"
+import { executeBatch } from "../../actions/wallet/executeBatch"
+import type {
   ExtendEntityParameters,
   ExtendEntityReturnType,
 } from "../../actions/wallet/extendEntity"
 import { extendEntity } from "../../actions/wallet/extendEntity"
-import type {
-  MutateEntitiesParameters,
-  MutateEntitiesReturnType,
-} from "../../actions/wallet/mutateEntities"
-import { mutateEntities } from "../../actions/wallet/mutateEntities"
 import type { PatchEntityParameters, PatchEntityReturnType } from "../../actions/wallet/patchEntity"
 import { patchEntity } from "../../actions/wallet/patchEntity"
 import type { TxParams } from "../../types"
@@ -51,7 +51,7 @@ export type WalletArkivActions<
      * Creates a new entity.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/createEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
      *
      * @param data - The entity creation parameters
      * @param txParams - Optional transaction parameters
@@ -92,7 +92,7 @@ export type WalletArkivActions<
      * everything it does not name alone.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/patchEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
      *
      * @param data - The entity key and the mutations to apply
      * @param txParams - Optional transaction parameters
@@ -132,7 +132,7 @@ export type WalletArkivActions<
      * Deletes the entity with the given key.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/deleteEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
      *
      * @param data - The entity deletion parameters
      * @param txParams - Optional transaction parameters
@@ -165,7 +165,7 @@ export type WalletArkivActions<
      * The engine rejects an extension that would not move the expiry later.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/extendEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
      *
      * @param data - The entity key and its new lifetime
      * @param txParams - Optional transaction parameters
@@ -200,7 +200,7 @@ export type WalletArkivActions<
      * Hands the entity with the given key to a new owner.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/changeOwnership
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
      *
      * @param data - The ownership change parameters
      * @param txParams - Optional transaction parameters
@@ -215,16 +215,16 @@ export type WalletArkivActions<
      * Applies a batch of entity operations — creates, patches, deletes, extensions and ownership
      * transfers — in one transaction.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/mutateEntities
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
+     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/executeBatch
+     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
      *
      * Every operation lands in one transaction, so the whole batch applies or none of it does.
      * At least one operation is required.
      *
-     * @param data - The mutation parameters (creates, patches, deletes, extensions, ownershipChanges)
+     * @param data - The batch parameters (creates, patches, deletes, extensions, ownershipChanges)
      * @param txParams - Optional transaction parameters
      * @returns The transaction hash, plus the keys touched by each kind of operation.
-     * {@link MutateEntitiesReturnType}
+     * {@link ExecuteBatchReturnType}
      *
      * @throws {InvalidExpiryError} If an expiry exceeds a protocol bound or would leave the entity
      * dead on arrival.
@@ -241,7 +241,7 @@ export type WalletArkivActions<
      *   chain: cheesecake,
      *   transport: http(),
      * })
-     * const { txHash, createdEntities } = await client.mutateEntities({
+     * const { txHash, createdEntities } = await client.executeBatch({
      *   creates: [{
      *     payload: jsonToPayload({ entityType: "testType", entityId: "testId" }),
      *     contentType: "application/json",
@@ -257,10 +257,10 @@ export type WalletArkivActions<
      *   ownershipChanges: [{ entityKey: keyToHandOver, newOwner }],
      * })
      */
-    mutateEntities: (
-      data: MutateEntitiesParameters,
+    executeBatch: (
+      data: ExecuteBatchParameters,
       txParams?: TxParams,
-    ) => Promise<MutateEntitiesReturnType>
+    ) => Promise<ExecuteBatchReturnType>
   }
 
 export function walletArkivActions<
@@ -279,7 +279,7 @@ export function walletArkivActions<
       extendEntity(client, data, txParams),
     changeOwnership: (data: ChangeOwnershipParameters, txParams?: TxParams) =>
       changeOwnership(client, data, txParams),
-    mutateEntities: (data: MutateEntitiesParameters, txParams?: TxParams) =>
-      mutateEntities(client, data, txParams),
+    executeBatch: (data: ExecuteBatchParameters, txParams?: TxParams) =>
+      executeBatch(client, data, txParams),
   }
 }

--- a/src/clients/decorators/arkivWallet.ts
+++ b/src/clients/decorators/arkivWallet.ts
@@ -55,7 +55,8 @@ export type WalletArkivActions<
      *
      * @param data - The entity creation parameters
      * @param txParams - Optional transaction parameters
-     * @returns The created entity with transaction hash
+     * @returns The new entity's key, the transaction hash, and the block it is expected to
+     * expire at. {@link CreateEntityReturnType}
      *
      * @throws {InvalidExpiryError} If the expiry exceeds a protocol bound or would leave the
      * entity dead on arrival.
@@ -67,8 +68,10 @@ export type WalletArkivActions<
      * import { i32 } from "@arkiv-network/sdk/attr"
      * import { cheesecake } from "@arkiv-network/sdk/chains"
      * import { http } from "viem"
+     * import { privateKeyToAccount } from "viem/accounts"
      *
      * const client = createWalletClient({
+     *   account: privateKeyToAccount("0x..."),
      *   chain: cheesecake,
      *   transport: http(),
      * })
@@ -93,7 +96,7 @@ export type WalletArkivActions<
      *
      * @param data - The entity key and the mutations to apply
      * @param txParams - Optional transaction parameters
-     * @returns The entity key and the transaction hash
+     * @returns The patched entity's key and the transaction hash. {@link PatchEntityReturnType}
      *
      * @throws {EmptyPatchError} If the patch has nothing to apply.
      * @throws {ConflictingMutationError} If a name appears in both `set` and `unset`.
@@ -105,8 +108,10 @@ export type WalletArkivActions<
      * import { i32 } from "@arkiv-network/sdk/attr"
      * import { cheesecake } from "@arkiv-network/sdk/chains"
      * import { http } from "viem"
+     * import { privateKeyToAccount } from "viem/accounts"
      *
      * const client = createWalletClient({
+     *   account: privateKeyToAccount("0x..."),
      *   chain: cheesecake,
      *   transport: http(),
      * })
@@ -131,14 +136,16 @@ export type WalletArkivActions<
      *
      * @param data - The entity deletion parameters
      * @param txParams - Optional transaction parameters
-     * @returns The deleted entity with transaction hash
+     * @returns The deleted entity's key and the transaction hash. {@link DeleteEntityReturnType}
      *
      * @example
      * import { createWalletClient } from "@arkiv-network/sdk"
      * import { cheesecake } from "@arkiv-network/sdk/chains"
      * import { http } from "viem"
+     * import { privateKeyToAccount } from "viem/accounts"
      *
      * const client = createWalletClient({
+     *   account: privateKeyToAccount("0x..."),
      *   chain: cheesecake,
      *   transport: http(),
      * })
@@ -162,7 +169,8 @@ export type WalletArkivActions<
      *
      * @param data - The entity key and its new lifetime
      * @param txParams - Optional transaction parameters
-     * @returns The entity key, transaction hash, and the block it is now expected to expire at
+     * @returns The entity's key, the transaction hash, and the block it is now expected to expire
+     * at. {@link ExtendEntityReturnType}
      *
      * @throws {InvalidExpiryError} If the expiry is malformed, exceeds a protocol bound, or would
      * leave the entity dead on arrival.
@@ -171,8 +179,10 @@ export type WalletArkivActions<
      * import { createWalletClient, ExpirationTime } from "@arkiv-network/sdk"
      * import { cheesecake } from "@arkiv-network/sdk/chains"
      * import { http } from "viem"
+     * import { privateKeyToAccount } from "viem/accounts"
      *
      * const client = createWalletClient({
+     *   account: privateKeyToAccount("0x..."),
      *   chain: cheesecake,
      *   transport: http(),
      * })
@@ -187,14 +197,14 @@ export type WalletArkivActions<
     ) => Promise<ExtendEntityReturnType>
 
     /**
-     * Changes the ownership of the entity with the given address.
+     * Hands the entity with the given key to a new owner.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/changeOwnership
      * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
      *
      * @param data - The ownership change parameters
      * @param txParams - Optional transaction parameters
-     * @returns The entity with updated ownership and transaction hash
+     * @returns The entity's key and the transaction hash. {@link ChangeOwnershipReturnType}
      */
     changeOwnership: (
       data: ChangeOwnershipParameters,
@@ -202,7 +212,8 @@ export type WalletArkivActions<
     ) => Promise<ChangeOwnershipReturnType>
 
     /**
-     * Mutates the entities with the given keys.
+     * Applies a batch of entity operations — creates, patches, deletes, extensions and ownership
+     * transfers — in one transaction.
      *
      * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/mutateEntities
      * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#mutateEntities)
@@ -212,7 +223,8 @@ export type WalletArkivActions<
      *
      * @param data - The mutation parameters (creates, patches, deletes, extensions, ownershipChanges)
      * @param txParams - Optional transaction parameters
-     * @returns The mutation result with transaction hash
+     * @returns The transaction hash, plus the keys touched by each kind of operation.
+     * {@link MutateEntitiesReturnType}
      *
      * @throws {InvalidExpiryError} If an expiry exceeds a protocol bound or would leave the entity
      * dead on arrival.
@@ -222,8 +234,10 @@ export type WalletArkivActions<
      * import { createWalletClient, ExpirationTime, jsonToPayload } from "@arkiv-network/sdk"
      * import { cheesecake } from "@arkiv-network/sdk/chains"
      * import { http } from "viem"
+     * import { privateKeyToAccount } from "viem/accounts"
      *
      * const client = createWalletClient({
+     *   account: privateKeyToAccount("0x..."),
      *   chain: cheesecake,
      *   transport: http(),
      * })

--- a/src/clients/decorators/arkivWallet.ts
+++ b/src/clients/decorators/arkivWallet.ts
@@ -50,8 +50,7 @@ export type WalletArkivActions<
     /**
      * Creates a new entity.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/createEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
+     * - JSON-RPC Methods: `eth_sendRawTransaction`
      *
      * @param data - The entity creation parameters
      * @param txParams - Optional transaction parameters
@@ -91,8 +90,7 @@ export type WalletArkivActions<
      * Applies a patch to the entity with the given key: sets some fields, unsets others, and leaves
      * everything it does not name alone.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/patchEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
+     * - JSON-RPC Methods: `eth_sendRawTransaction`
      *
      * @param data - The entity key and the mutations to apply
      * @param txParams - Optional transaction parameters
@@ -131,8 +129,7 @@ export type WalletArkivActions<
     /**
      * Deletes the entity with the given key.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/deleteEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
+     * - JSON-RPC Methods: `eth_sendRawTransaction`
      *
      * @param data - The entity deletion parameters
      * @param txParams - Optional transaction parameters
@@ -164,8 +161,7 @@ export type WalletArkivActions<
      * than adding to what the entity has left, and `atBlock` / `atDate` pin an absolute deadline.
      * The engine rejects an extension that would not move the expiry later.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/extendEntity
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
+     * - JSON-RPC Methods: `eth_sendRawTransaction`
      *
      * @param data - The entity key and its new lifetime
      * @param txParams - Optional transaction parameters
@@ -199,8 +195,7 @@ export type WalletArkivActions<
     /**
      * Hands the entity with the given key to a new owner.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/changeOwnership
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
+     * - JSON-RPC Methods: `eth_sendRawTransaction`
      *
      * @param data - The ownership change parameters
      * @param txParams - Optional transaction parameters
@@ -215,8 +210,7 @@ export type WalletArkivActions<
      * Applies a batch of entity operations — creates, patches, deletes, extensions and ownership
      * transfers — in one transaction.
      *
-     * - Docs: https://docs.arkiv.network/ts-sdk/actions/wallet/executeBatch
-     * - JSON-RPC Methods: [`eth_sendRawTransaction`](https://docs.arkiv.network/dev/json-rpc-api/#executeBatch)
+     * - JSON-RPC Methods: `eth_sendRawTransaction`
      *
      * Every operation lands in one transaction, so the whole batch applies or none of it does.
      * At least one operation is required.

--- a/src/entity/create.test.ts
+++ b/src/entity/create.test.ts
@@ -4,7 +4,7 @@ import { encodeAttributes } from "../attr/attributes"
 import { dec, i32, str, u256 } from "../attr/values"
 import { InvalidCreationFlagsError } from "./errors"
 import { decodeCreationFlags, encodeCreationFlags } from "./flags"
-import { MAX_SALT, predictEntityKey, randomSalt, validateSalt } from "./key"
+import { MAX_SALT, NO_SALT, predictEntityKey, randomSalt, resolveSalt, validateSalt } from "./key"
 import { createOperation } from "./operations"
 import { OperationType } from "./params"
 
@@ -73,6 +73,18 @@ describe("salt", () => {
     expect(() => validateSalt(MAX_SALT + 1n)).toThrow(/uint128/)
     expect(() => validateSalt(-1n)).toThrow(/uint128/)
   })
+
+  it("resolves NO_SALT to the zero, and passes anything else through", () => {
+    expect(resolveSalt(NO_SALT)).toBe(0n)
+    expect(resolveSalt(0n)).toBe(0n)
+    expect(resolveSalt(42n)).toBe(42n)
+    expect(() => resolveSalt(MAX_SALT + 1n)).toThrow(/uint128/)
+  })
+
+  it("reports a salt it cannot use without choking on a symbol", () => {
+    // @ts-expect-error
+    expect(() => validateSalt(Symbol("nope"))).toThrow(/Invalid salt/)
+  })
 })
 
 describe("predictEntityKey", () => {
@@ -84,6 +96,13 @@ describe("predictEntityKey", () => {
     expect(
       predictEntityKey({ ...base, owner: "0x1111111111111111111111111111111111111111" }),
     ).not.toBe(predictEntityKey(base))
+  })
+
+  it("derives the same key from NO_SALT as from an explicit zero", () => {
+    const base = { owner: OWNER, nonce: 3n, chainId: 1 } as const
+    expect(predictEntityKey({ ...base, salt: NO_SALT })).toBe(
+      predictEntityKey({ ...base, salt: 0n }),
+    )
   })
 
   it("separates chains through the domain", () => {

--- a/src/entity/errors.ts
+++ b/src/entity/errors.ts
@@ -16,10 +16,11 @@ export class InvalidCreationFlagsError extends Error {
 
 /** A key salt was outside the `uint128` the wire carries. */
 export class InvalidSaltError extends Error {
-  constructor(salt: bigint) {
+  constructor(salt: unknown) {
     super(
-      `Invalid salt ${salt}. A salt is a uint128, so it must be between 0 and ` +
-        `${2n ** 128n - 1n}. Omit it to get 128 random bits, or pass 0 for a predictable key.`,
+      `Invalid salt ${String(salt)}. A salt is a uint128, so it must be between 0 and ` +
+        `${2n ** 128n - 1n}. Omit it to get 128 random bits, or pass NO_SALT for a key derived ` +
+        `from the owner and nonce alone.`,
     )
     this.name = "InvalidSaltError"
   }

--- a/src/entity/expiry.ts
+++ b/src/entity/expiry.ts
@@ -1,4 +1,5 @@
 import { BLOCK_TIME } from "../consts"
+import type { ExpirationTime } from "../utils/expirationTime"
 import { InvalidExpiryError } from "./errors"
 import { MAX_EXPIRES_AT } from "./params"
 

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -10,5 +10,6 @@ export type { EncodedExpiry, Expiry, ExpiryContext, Lifetime, ResolvedExpiry } f
 export { resolveExpiry, toBlocks } from "./expiry"
 export type { CreationFlags, ResolvedCreationFlags } from "./flags"
 export { decodeCreationFlags, encodeCreationFlags } from "./flags"
-export { MAX_SALT, predictEntityKey, randomSalt } from "./key"
+export type { SaltInput } from "./key"
+export { MAX_SALT, NO_SALT, predictEntityKey, randomSalt } from "./key"
 export { MAX_EXPIRES_AT, OperationType } from "./params"

--- a/src/entity/key.ts
+++ b/src/entity/key.ts
@@ -1,4 +1,5 @@
 import { type Address, encodePacked, type Hex, keccak256 } from "viem"
+import type { CreateEntityParameters } from "../actions/wallet/createEntity"
 import { ARKIV_ADDRESS } from "../consts"
 import { InvalidSaltError, NoRandomSourceError } from "./errors"
 

--- a/src/entity/key.ts
+++ b/src/entity/key.ts
@@ -7,6 +7,18 @@ import { InvalidSaltError, NoRandomSourceError } from "./errors"
 export const MAX_SALT = 2n ** 128n - 1n
 
 /**
+ * Opts a create out of salting, as {@link CreateEntityParameters.salt}: the key is then derived
+ * from the owner and its nonce alone, so anyone who knows both can work it out before the create
+ * lands.
+ */
+export const NO_SALT = Symbol("NO_SALT")
+
+/**
+ * A salt as a caller expresses it: an explicit `uint128`, or {@link NO_SALT} to opt out of salting.
+ */
+export type SaltInput = bigint | typeof NO_SALT
+
+/**
  * A cryptographically random 128-bit salt — what {@link CreateEntityParameters.salt} defaults to.
  *
  * The salt exists for unpredictability, not uniqueness: the per-owner nonce already guarantees
@@ -24,6 +36,13 @@ export function randomSalt(): bigint {
   let salt = 0n
   for (const byte of bytes) salt = (salt << 8n) | BigInt(byte)
   return salt
+}
+
+/**
+ * Resolves a caller-supplied salt to a `uint128`.
+ */
+export function resolveSalt(salt: SaltInput): bigint {
+  return salt === NO_SALT ? 0n : validateSalt(salt)
 }
 
 /** Validates a caller-supplied salt against the `uint128` wire field. */
@@ -55,15 +74,15 @@ export function predictEntityKey({
    * create in a batch uses `nonce + n`.
    */
   nonce: bigint
-  /** The salt the create will carry. */
-  salt: bigint
+  /** The salt the create will carry, or {@link NO_SALT} if it carries none. */
+  salt: SaltInput
   /** The chain the entity is being created on — half of the derivation domain. */
   chainId: number
 }): Hex {
   return keccak256(
     encodePacked(
       ["uint256", "address", "address", "uint64", "uint128"],
-      [BigInt(chainId), ARKIV_ADDRESS, owner, nonce, validateSalt(salt)],
+      [BigInt(chainId), ARKIV_ADDRESS, owner, nonce, resolveSalt(salt)],
     ),
   )
 }

--- a/src/entity/operations.ts
+++ b/src/entity/operations.ts
@@ -1,6 +1,7 @@
 import { type Address, encodeAbiParameters, type Hex, parseAbi, parseAbiParameters } from "viem"
 import type { AbiAttribute } from "../attr/codec"
 import type { EncodedExpiry } from "./expiry"
+import type { predictEntityKey } from "./key"
 import { OperationType } from "./params"
 
 /**

--- a/src/query/errors.ts
+++ b/src/query/errors.ts
@@ -10,7 +10,7 @@ import type { TypeTag } from "../attr"
  * | | `=` `!=` | `<` `<=` `>` `>=` | `STARTSWITH` |
  * | --- | --- | --- | --- |
  * | `bool` | yes | no | no |
- * | `i32` `u256` `dec` | yes | yes | no |
+ * | `i32` `u64` `u256` `dec` | yes | yes | no |
  * | `str` | yes | no | yes |
  * | `addr` `key` `bytes32` | yes | no | no |
  */

--- a/src/query/expression.ts
+++ b/src/query/expression.ts
@@ -12,6 +12,10 @@ import {
 import { TYPE_IDS } from "../attr/types"
 import { InvalidPredicateError, UnsupportedOperatorError } from "./errors"
 
+/**
+ * The comparison operators the query language defines. `<` `<=` `>` `>=` need an ordered type —
+ * `i32`, `u64`, `u256` or `dec`; every type accepts `=` and `!=`.
+ */
 export type ComparisonOperator = "=" | "!=" | "<" | "<=" | ">" | ">="
 
 /** A comparison between an attribute and a typed literal. */
@@ -216,7 +220,7 @@ export function ne(name: string, value: ValueInput): ComparisonNode {
 }
 
 /**
- * Attribute is greater than value. Ordered types only (`i32`, `u256`, `dec`).
+ * Attribute is greater than value. Ordered types only (`i32`, `u64`, `u256`, `dec`).
  *
  * @throws {UnsupportedOperatorError} If the value's type carries no ordered index.
  *
@@ -229,7 +233,7 @@ export function gt(name: string, value: ValueInput): ComparisonNode {
 }
 
 /**
- * Attribute is greater than or equal to value. Ordered types only (`i32`, `u256`, `dec`).
+ * Attribute is greater than or equal to value. Ordered types only (`i32`, `u64`, `u256`, `dec`).
  *
  * @throws {UnsupportedOperatorError} If the value's type carries no ordered index.
  *
@@ -241,7 +245,7 @@ export function gte(name: string, value: ValueInput): ComparisonNode {
 }
 
 /**
- * Attribute is less than value. Ordered types only (`i32`, `u256`, `dec`).
+ * Attribute is less than value. Ordered types only (`i32`, `u64`, `u256`, `dec`).
  *
  * @throws {UnsupportedOperatorError} If the value's type carries no ordered index.
  *
@@ -253,7 +257,7 @@ export function lt(name: string, value: ValueInput): ComparisonNode {
 }
 
 /**
- * Attribute is less than or equal to value. Ordered types only (`i32`, `u256`, `dec`).
+ * Attribute is less than or equal to value. Ordered types only (`i32`, `u64`, `u256`, `dec`).
  *
  * @throws {UnsupportedOperatorError} If the value's type carries no ordered index.
  *
@@ -271,7 +275,9 @@ export function lte(name: string, value: ValueInput): ComparisonNode {
  * `startsWith("name", "é")` matches only the same byte sequence, not another normal form of it.
  *
  * @param prefix - The prefix, as a bare string or a `str` value.
- * @throws {UnsupportedOperatorError} If given a value that is not a `str`.
+ * @throws {InvalidPredicateError} If the name is not a queryable attribute.
+ * @throws {UnsupportedOperatorError} If given a value that is not a `str`, or a system attribute
+ * (none of which is a `str`).
  *
  * @example
  * startsWith("desc", "ab") // desc STARTSWITH str('ab')
@@ -325,7 +331,8 @@ export function exists(name: string): ExistsNode {
  * Useful when the same name is written with different types across entities — a comparison already
  * asserts the type, so this is for asking about the type alone.
  *
- * @param tag - The type tag: `bool`, `i32`, `u256`, `dec`, `bytes32`, `str`, `addr` or `key`.
+ * @param tag - The type tag: `bool`, `i32`, `u64`, `u256`, `dec`, `bytes32`, `str`, `addr` or
+ * `key`.
  * @throws {InvalidPredicateError} If the tag is not a settable type, or the name is a system
  * attribute (whose type is fixed).
  *
@@ -344,7 +351,7 @@ export function hasType(name: string, tag: UserTypeTag): TypeOfNode {
   if (!isUserTypeTag(tag)) {
     throw new InvalidPredicateError(
       `"${tag}" is not a settable attribute type. Use one of ` +
-        "bool, i32, u256, dec, bytes32, str, addr, key.",
+        "bool, i32, u64, u256, dec, bytes32, str, addr, key.",
       name,
     )
   }

--- a/src/query/queryBuilder.ts
+++ b/src/query/queryBuilder.ts
@@ -5,7 +5,7 @@ import type { Entity } from "../types/entity"
 import type { RpcSelect } from "../types/rpcSchema"
 import { type QueryRequest, runQuery } from "./engine"
 import { InvalidPredicateError } from "./errors"
-import { and, type Expression, eq } from "./expression"
+import { and, type Expression, eq, type or } from "./expression"
 import { QueryResult } from "./queryResult"
 import { type SelectArg, toRpcSelect } from "./selection"
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,11 +12,11 @@ export type {
 } from "../actions/wallet/changeOwnership"
 export type { CreateEntityParameters, CreateEntityReturnType } from "../actions/wallet/createEntity"
 export type { DeleteEntityParameters, DeleteEntityReturnType } from "../actions/wallet/deleteEntity"
-export type { ExtendEntityParameters, ExtendEntityReturnType } from "../actions/wallet/extendEntity"
 export type {
-  MutateEntitiesParameters,
-  MutateEntitiesReturnType,
-} from "../actions/wallet/mutateEntities"
+  ExecuteBatchParameters,
+  ExecuteBatchReturnType,
+} from "../actions/wallet/executeBatch"
+export type { ExtendEntityParameters, ExtendEntityReturnType } from "../actions/wallet/extendEntity"
 export type { PatchEntityParameters, PatchEntityReturnType } from "../actions/wallet/patchEntity"
 export type { EntityFields } from "./entity"
 export { Entity } from "./entity"

--- a/src/types/rpcSchema.ts
+++ b/src/types/rpcSchema.ts
@@ -69,6 +69,7 @@ export type RpcSelect = {
   attributes?: boolean | Record<string, boolean>
 }
 
+/** The second parameter of `arkiv_query` — what to return, and where in the results to start. */
 export type RpcQueryOptions = {
   /** Block height to read at, as a hex quantity. Defaults to the head, and must be within the node's retained range. */
   atBlock?: Hex

--- a/src/types/txParams.ts
+++ b/src/types/txParams.ts
@@ -1,3 +1,11 @@
+/**
+ * Transaction fields a write action passes through to the wallet, for the cases where the defaults
+ * are not what you want.
+ *
+ * Fee style is either/or: give `gasPrice` for a legacy transaction, or `maxFeePerGas` /
+ * `maxPriorityFeePerGas` for an EIP-1559 one. Mixing the two does not typecheck. Anything left out
+ * is estimated.
+ */
 export type TxParams =
   | {
       gas?: bigint

--- a/src/utils/arkivTransactions.test.ts
+++ b/src/utils/arkivTransactions.test.ts
@@ -23,7 +23,7 @@ import {
 } from "../attr"
 import type { ArkivClient } from "../clients/baseClient"
 import { ARKIV_ADDRESS } from "../consts"
-import { InvalidExpiryError } from "../entity"
+import { InvalidExpiryError, NO_SALT } from "../entity"
 import { ENTITY_EVENTS_ABI, type EntityEventName } from "../entity/events"
 import { MAX_EXPIRES_AT, OperationType } from "../entity/params"
 import { EmptyPatchError, EntityMutationError } from "../errors"
@@ -302,6 +302,12 @@ describe("creation flags and salt", () => {
     const { client: c2, writeContract: w2 } = makeClient()
     await sendArkivTransaction(c2, { creates: [{ ...validCreate, salt: 0n }] })
     expect(sentCreate(w2).salt).toBe(0n)
+  })
+
+  it("sends a zero salt for a create that opts out with NO_SALT", async () => {
+    const { client, writeContract } = makeClient()
+    await sendArkivTransaction(client, { creates: [{ ...validCreate, salt: NO_SALT }] })
+    expect(sentCreate(writeContract).salt).toBe(0n)
   })
 
   it("rejects a salt wider than the uint128 field", async () => {

--- a/src/utils/arkivTransactions.ts
+++ b/src/utils/arkivTransactions.ts
@@ -21,7 +21,7 @@ import { ARKIV_ADDRESS } from "../consts"
 import { ENTITY_EVENTS_ABI } from "../entity/events"
 import { resolveExpiry } from "../entity/expiry"
 import { encodeCreationFlags } from "../entity/flags"
-import { randomSalt, validateSalt } from "../entity/key"
+import { randomSalt, resolveSalt } from "../entity/key"
 import {
   createOperation,
   deleteOperation,
@@ -118,7 +118,7 @@ export async function sendArkivTransaction(
   const createOps = (creates ?? []).map((item) => {
     validateContentType(item.contentType)
 
-    const salt = item.salt === undefined ? randomSalt() : validateSalt(item.salt)
+    const salt = item.salt === undefined ? randomSalt() : resolveSalt(item.salt)
     const expiry = resolveExpiry(item.expires, expiryContext)
 
     return createOperation({

--- a/src/utils/expirationTime.ts
+++ b/src/utils/expirationTime.ts
@@ -51,11 +51,50 @@ export const ExpirationTime = {
    * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
    */
   fromSeconds: (seconds: number): Lifetime => lifetimeOf(seconds),
+  /**
+   * A number of minutes.
+   *
+   * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
+   */
   fromMinutes: (minutes: number): Lifetime => lifetimeOf(minutes * 60),
+
+  /**
+   * A number of hours.
+   *
+   * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
+   */
   fromHours: (hours: number): Lifetime => lifetimeOf(hours * 60 * 60),
+
+  /**
+   * A number of days. The everyday form — `fromDays(30)` is what most creates want.
+   *
+   * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
+   */
   fromDays: (days: number): Lifetime => lifetimeOf(days * 24 * 60 * 60),
+
+  /**
+   * A number of weeks, each of 7 days.
+   *
+   * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
+   */
   fromWeeks: (weeks: number): Lifetime => lifetimeOf(weeks * 7 * 24 * 60 * 60),
+
+  /**
+   * A number of months, each of exactly **30 days** — calendar months are not all the same length,
+   * and a lifetime is a duration rather than a date. Use {@link ExpirationTime.atDate} when the
+   * expiry has to land on a particular calendar day.
+   *
+   * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
+   */
   fromMonths: (months: number): Lifetime => lifetimeOf(months * 30 * 24 * 60 * 60),
+
+  /**
+   * A number of years, each of exactly **365 days** — leap days are not counted, so `fromYears(4)`
+   * is a day short of four calendar years. Use {@link ExpirationTime.atDate} for a calendar
+   * deadline.
+   *
+   * @throws {InvalidExpiryError} If the duration is not a positive multiple of the block time.
+   */
   fromYears: (years: number): Lifetime => lifetimeOf(years * 365 * 24 * 60 * 60),
 
   /**

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -1,9 +1,34 @@
 import { stringToBytes, toBytes } from "viem"
 
+/**
+ * A JSON-serialisable value as an entity payload — `JSON.stringify` then UTF-8.
+ *
+ * Pair it with `contentType: "application/json"`, which is what lets `entity.toJson()` read it back.
+ *
+ * @example
+ * await client.createEntity({
+ *   payload: jsonToPayload({ hello: "world" }),
+ *   contentType: "application/json",
+ *   expires: ExpirationTime.fromDays(30),
+ * })
+ */
 export function jsonToPayload(json: object): Uint8Array {
   return toBytes(JSON.stringify(json))
 }
 
+/**
+ * A string as an entity payload, encoded as UTF-8.
+ *
+ * Hex-looking text is encoded as text: `stringToPayload("0xab")` gives the four bytes of that
+ * string, not the single byte `0xab`. Read it back with `entity.toText()`.
+ *
+ * @example
+ * await client.createEntity({
+ *   payload: stringToPayload("hello"),
+ *   contentType: "text/plain",
+ *   expires: ExpirationTime.fromDays(30),
+ * })
+ */
 export function stringToPayload(data: string): Uint8Array {
   // stringToBytes, not toBytes: toBytes hex-decodes hex-looking strings, which
   // would corrupt payloads like "0xab" instead of UTF-8 encoding them

--- a/test/src/arkiv.test.ts
+++ b/test/src/arkiv.test.ts
@@ -367,7 +367,7 @@ describe("Arkiv Integration Tests for public client", () => {
     "a batch applies every one of its operations in one transaction",
     async () => {
       // Five entities to operate on, created in one batch rather than five transactions.
-      const seed = await walletClient.mutateEntities({
+      const seed = await walletClient.executeBatch({
         creates: Array.from({ length: 5 }, () => ({
           payload: jsonToPayload({ entity: { entityType: "test", entityId: "test" } }),
           contentType: "application/json" as const,
@@ -382,7 +382,7 @@ describe("Arkiv Integration Tests for public client", () => {
         throw new Error(`expected 5 seeded keys, got ${seed.createdEntities.length}`)
       }
 
-      const result = await walletClient.mutateEntities({
+      const result = await walletClient.executeBatch({
         creates: [
           {
             payload: jsonToPayload({ entity: { entityType: "test", entityId: "test" } }),
@@ -430,7 +430,7 @@ describe("Arkiv Integration Tests for public client", () => {
 
       // One good create, one impossible delete. The create must not survive the batch.
       await expect(
-        walletClient.mutateEntities({
+        walletClient.executeBatch({
           creates: [
             {
               payload: stringToPayload("should never exist"),
@@ -610,7 +610,7 @@ describe("Arkiv Integration Tests for public client", () => {
     "the operators the engine supports filter as written",
     async () => {
       const group = `operators-${crypto.randomUUID()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: [100, 200, 300, 400, 500].map((score) => ({
           payload: jsonToPayload({ entity: { entityType: "rangetest", entityId: `s-${score}` } }),
           contentType: "application/json" as const,
@@ -652,7 +652,7 @@ describe("Arkiv Integration Tests for public client", () => {
     "a large result set pages without losing or repeating anything",
     async () => {
       const value = `paging-${crypto.randomUUID()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: Array.from({ length: 10 }, () => ({
           payload: jsonToPayload({ entity: { entityType: "test", entityId: "test" } }),
           contentType: "application/json" as const,
@@ -854,7 +854,7 @@ describe("Arkiv Integration Tests for public client", () => {
     async () => {
       const before = await publicClient.getEntityCount()
 
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: Array.from({ length: 3 }, () => ({
           payload: stringToPayload("counted"),
           contentType: "text/plain" as const,
@@ -877,7 +877,7 @@ describe("Arkiv Integration Tests for public client", () => {
     async (transport) => {
       const { read, write } = clients(transport)
 
-      const seed = await write.mutateEntities({
+      const seed = await write.executeBatch({
         creates: Array.from({ length: 3 }, () => ({
           payload: stringToPayload("seed"),
           contentType: "text/plain" as const,
@@ -901,7 +901,7 @@ describe("Arkiv Integration Tests for public client", () => {
       })
 
       try {
-        const batch = await write.mutateEntities({
+        const batch = await write.executeBatch({
           creates: [
             {
               payload: stringToPayload("created under watch"),
@@ -1026,7 +1026,7 @@ describe("Arkiv Integration Tests for public client", () => {
       })
       expect(parent.key).not.toBe(child.key)
 
-      const batch = await walletClient.mutateEntities({
+      const batch = await walletClient.executeBatch({
         creates: [
           {
             payload: stringToPayload("parent"),

--- a/test/src/network-health.test.ts
+++ b/test/src/network-health.test.ts
@@ -389,7 +389,7 @@ describe(`Network health check (${chain.name})`, () => {
     "a batch applies every one of its operations, or none",
     async () => {
       const tag = `batch-${Date.now()}`
-      const pre = await walletClient.mutateEntities({
+      const pre = await walletClient.executeBatch({
         creates: (["patch", "delete", "extend", "transfer"] as const).map((purpose) => ({
           payload: jsonToPayload({ batch: purpose }),
           contentType: "application/json" as const,
@@ -406,7 +406,7 @@ describe(`Network health check (${chain.name})`, () => {
       const expiryBefore = (await publicClient.getEntity(toExtend)).expiresAt ?? 0n
 
       const newOwner = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as Hex
-      const result = await walletClient.mutateEntities({
+      const result = await walletClient.executeBatch({
         creates: [
           {
             payload: jsonToPayload({ batch: "created" }),
@@ -453,7 +453,7 @@ describe(`Network health check (${chain.name})`, () => {
 
       // The second entity points at the first, whose key does not exist yet — which is the whole
       // reason to predict one.
-      const batch = await walletClient.mutateEntities({
+      const batch = await walletClient.executeBatch({
         creates: [
           {
             payload: jsonToPayload({ role: "parent" }),
@@ -496,7 +496,7 @@ describe(`Network health check (${chain.name})`, () => {
     async () => {
       const group = `filter-${Date.now()}`
 
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: [10, 20, 30, 40, 50].map((score) => ({
           payload: jsonToPayload({ group, score }),
           contentType: "application/json" as const,
@@ -600,7 +600,7 @@ describe(`Network health check (${chain.name})`, () => {
     "a large result set pages without losing or repeating anything",
     async () => {
       const group = `page-${Date.now()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: Array.from({ length: 8 }, (_, index) => ({
           payload: jsonToPayload({ group, index }),
           contentType: "application/json" as const,
@@ -814,7 +814,7 @@ describe(`Network health check (${chain.name})`, () => {
     "STARTSWITH matches a string prefix",
     async () => {
       const group = `prefix-${Date.now()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: ["alpha-one", "alpha-two", "beta-one"].map((label) => ({
           payload: jsonToPayload({ group, label }),
           contentType: "application/json" as const,
@@ -843,7 +843,7 @@ describe(`Network health check (${chain.name})`, () => {
     "EXISTS finds attributes by presence, whatever they hold",
     async () => {
       const group = `exists-${Date.now()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: [
           {
             payload: jsonToPayload({ group, has: true }),
@@ -877,7 +877,7 @@ describe(`Network health check (${chain.name})`, () => {
     "TYPEOF tells apart one name written with two types",
     async () => {
       const group = `typeof-${Date.now()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: [
           {
             payload: jsonToPayload({ group, kind: "number" }),
@@ -971,7 +971,7 @@ describe(`Network health check (${chain.name})`, () => {
     "a rejected query says which kind of rejection it was",
     async () => {
       const group = `errors-${Date.now()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: [1, 2].map((index) => ({
           payload: jsonToPayload({ group, index }),
           contentType: "application/json" as const,
@@ -1127,7 +1127,7 @@ describe(`Network health check (${chain.name})`, () => {
 
       // One good operation and one impossible one
       await expect(
-        walletClient.mutateEntities({
+        walletClient.executeBatch({
           patches: [{ entityKey, set: { purpose: "atomic_changed" } }],
           deletes: [{ entityKey: `0x${"88".repeat(32)}` as Hex }],
         }),
@@ -1168,7 +1168,7 @@ describe(`Network health check (${chain.name})`, () => {
           attributes: { purpose: "handler_test" },
           expires: SHORT,
         }
-        const created = await walletClient.mutateEntities({
+        const created = await walletClient.executeBatch({
           creates: [
             { ...base, payload: jsonToPayload({ role: "mutated" }) },
             { ...base, payload: jsonToPayload({ role: "transferred" }) },
@@ -1293,7 +1293,7 @@ describe(`Network health check (${chain.name})`, () => {
       ] as const
 
       const group = `nested-query-${Date.now()}`
-      const created = await walletClient.mutateEntities({
+      const created = await walletClient.executeBatch({
         creates: rows.map((row) => ({
           payload: jsonToPayload({ id: row.id }),
           contentType: "application/json" as const,

--- a/typedoc.json
+++ b/typedoc.json
@@ -15,7 +15,15 @@
   "excludeProtected": true,
   "excludeInternal": true,
   "excludeExternals": true,
-  "intentionallyNotExported": ["AtLeastOne", "AllSelected", "Selected", "FetchPage"],
+  "intentionallyNotExported": [
+    "AtLeastOne",
+    "AllSelected",
+    "Selected",
+    "FetchPage",
+    "Value",
+    "Repeat",
+    "TYPE_IDS"
+  ],
   "theme": "default",
   "outputs": [
     {


### PR DESCRIPTION
- Fix broken type references in jsdoc
- Remove 404 docs pages from jsdoc
- Rename `mutateEntities` to `executeBatch`
- Introduce `NO_SALT` symbol